### PR TITLE
Move back to Typhoeus

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,19 +2,12 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.0
 
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
-
-Style/StringLiteralsInInterpolation:
-  Enabled: true
-  EnforcedStyle: double_quotes
-
 Layout/LineLength:
   Max: 120
   Exclude:
     - lib/esi/client/*.rb
     - spec/lib/esi/client/*_spec.rb
+    - spec/lib/esi/client_spec.rb
     - Rakefile
 
 Metrics/BlockLength:

--- a/.yardext.rb
+++ b/.yardext.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require "kramdown"
-require "yard"
+require 'kramdown'
+require 'yard'
 
 # Make new Kramdown class with Github Formatted Markdown on
 class KramdownGFM < Kramdown::Document
   def initialize(text, opts = {})
-    super(text, opts.merge(input: "GFM", hard_wrap: false))
+    super(text, opts.merge(input: 'GFM', hard_wrap: false))
   end
 end
 
 # Register new KramdownGFM
 YARD::Templates::Helpers::MarkupHelper::MARKUP_PROVIDERS[:markdown] <<
-  { lib: :"kramdown-parser-gfm", const: "KramdownGFM" }
+  { lib: :'kramdown-parser-gfm', const: 'KramdownGFM' }
 
 # Register custom templates
-YARD::Templates::Engine.register_template_path File.expand_path("yard/templates", __dir__)
+YARD::Templates::Engine.register_template_path File.expand_path('yard/templates', __dir__)

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-ruby "3.0.2"
+ruby '3.0.2'
 
 gemspec
 
-gem "activesupport", "~> 6.1"
-gem "awesome_print", "~> 1.9"
-gem "rake", "~> 13.0"
-gem "rspec", "~> 3.10"
-gem "rubocop", "~> 1.18"
-gem "rubocop-performance", "~> 1.11"
-gem "rubocop-rake", "~> 0.6"
-gem "rubocop-rspec", "~> 2.4"
-gem "simplecov", "~> 0.21"
-gem "webmock", "~> 3.13"
-gem "yard", "~> 0.9"
+gem 'activesupport', '~> 6.1'
+gem 'awesome_print', '~> 1.9'
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.10'
+gem 'rubocop', '~> 1.18'
+gem 'rubocop-performance', '~> 1.11'
+gem 'rubocop-rake', '~> 0.6'
+gem 'rubocop-rspec', '~> 2.4'
+gem 'simplecov', '~> 0.21'
+gem 'webmock', '~> 3.14'
+gem 'yard', '~> 0.9'
 
-gem "kramdown-parser-gfm", "~> 1.1"
+gem 'kramdown-parser-gfm', '~> 1.1'
 
-gem "rouge", "~> 3.26"
+gem 'rouge', '~> 3.26'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,9 @@ PATH
   remote: .
   specs:
     esi-sdk (2.1.3)
-      httpx (~> 0.18)
+      oj (~> 3.13)
       retriable (~> 3.1)
+      typhoeus (~> 1.4)
 
 GEM
   remote: https://rubygems.org/
@@ -23,10 +24,10 @@ GEM
       rexml
     diff-lcs (1.4.4)
     docile (1.4.0)
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
+    ffi (1.15.5)
     hashdiff (1.0.1)
-    http-2-next (0.5.0)
-    httpx (0.18.1)
-      http-2-next (>= 0.4.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     kramdown (2.3.1)
@@ -34,6 +35,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     minitest (5.14.4)
+    oj (3.13.11)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -82,6 +84,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -109,7 +113,7 @@ DEPENDENCIES
   rubocop-rake (~> 0.6)
   rubocop-rspec (~> 2.4)
   simplecov (~> 0.21)
-  webmock (~> 3.13)
+  webmock (~> 3.14)
   yard (~> 0.9)
 
 RUBY VERSION

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
-require "yard"
-require "yard/rake/yardoc_task"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'yard'
+require 'yard/rake/yardoc_task'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-require "rubocop/rake_task"
+require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
@@ -16,30 +16,30 @@ YARD::Rake::YardocTask.new(:doc)
 task default: %i[spec rubocop]
 
 task :set_version do
-  version_file = File.join(File.dirname(__FILE__), "lib/esi/version.rb")
+  version_file = File.join(File.dirname(__FILE__), 'lib/esi/version.rb')
   version_content = File.read(version_file)
-  new_version = ENV["VERSION"]
+  new_version = ENV['VERSION']
   new_content = version_content.gsub(/VERSION = ".+"/m, "VERSION = \"#{new_version}\"")
-  File.write("lib/esi/version.rb", new_content)
+  File.write('lib/esi/version.rb', new_content)
 end
 
 task :generate do
-  require "active_support/core_ext/string/inflections"
-  require "json"
-  require "open-uri"
+  require 'active_support/core_ext/string/inflections'
+  require 'json'
+  require 'open-uri'
 
-  swagger = JSON.parse(URI.open("https://esi.evetech.net/latest/swagger.json").read)
+  swagger = JSON.parse(URI.open('https://esi.evetech.net/latest/swagger.json').read)
 
-  paths = swagger["paths"]
+  paths = swagger['paths']
   all_operations = paths.each_with_object({}) do |(path, operations), h|
     operations.each do |(http_method, operation)|
-      description = operation["description"].split("\n").first.strip
+      description = operation['description'].split("\n").first.strip
 
-      method_name_parts = path.split("/").map { |p| p.gsub(/[{}]/, "") }.map { |p| p.gsub(/_id/, "") }
-      operation_name = operation["operationId"]
+      method_name_parts = path.split('/').map { |p| p.gsub(/[{}]/, '') }.map { |p| p.gsub(/_id/, '') }
+      operation_name = operation['operationId']
       method_name_parts.map! do |p|
         if [(method_name_parts[method_name_parts.index(p) + 1]).to_s,
-            "#{method_name_parts[method_name_parts.index(p) + 1]}s", ""].include?(p)
+            "#{method_name_parts[method_name_parts.index(p) + 1]}s", ''].include?(p)
           nil
         else
           p
@@ -55,75 +55,73 @@ task :generate do
           p.singularize
         end
       end
-      method_name = "#{http_method}_#{method_name_parts.compact.join("_")}"
+      method_name = "#{http_method}_#{method_name_parts.compact.join('_')}"
 
-      path_params = operation["parameters"].select { |p| p["in"] == "path" || p["$ref"] }
+      path_params = operation['parameters'].select { |p| p['in'] == 'path' || p['$ref'] }
       path_params.map! do |param|
-        if param["$ref"]
-          ref_name = param["$ref"].match(%r{#/parameters/(alliance_id|corporation_id|character_id)})
+        if param['$ref']
+          ref_name = param['$ref'].match(%r{#/parameters/(alliance_id|corporation_id|character_id)})
           ref_name = ref_name[1] if ref_name
 
           next unless ref_name
 
-          swagger["parameters"][ref_name]
+          swagger['parameters'][ref_name]
         else
           param
         end
       end
-      path_params.compact!.sort_by! { |p| p["name"] }
+      path_params.compact!.sort_by! { |p| p['name'] }
 
-      body_param = operation["parameters"].select { |p| p["in"] == "body" }.first
+      body_param = operation['parameters'].select { |p| p['in'] == 'body' }.first
 
-      tag = operation["tags"].first || "Untagged"
+      tag = operation['tags'].first || 'Untagged'
       operation[tag]
 
-      scopes = (operation["security"].first["evesso"] if operation["security"].present?)
+      scopes = (operation['security'].first['evesso'] if operation['security'].present?)
 
-      cache = operation["x-cached-seconds"]
-      errors = operation["responses"].reject { |(k, _)| %w[200 201 204 304].include?(k) }
-      versions = operation["x-alternate-versions"]
+      cache = operation['x-cached-seconds']
+      errors = operation['responses'].reject { |(k, _)| %w[200 201 204 304].include?(k) }
+      versions = operation['x-alternate-versions']
 
-      query = operation["parameters"].select { |p| p["in"] == "query" }
+      query = operation['parameters'].select { |p| p['in'] == 'query' }
 
       h[method_name] =
         { params: path_params, method: http_method, description: description, tag: tag, path: path,
           name: operation_name, body: body_param, scopes: scopes, cache: cache, versions: versions, errors: errors,
-          responses: operation["responses"], query: query }
+          responses: operation['responses'], query: query }
     end
   end
 
   method_aliases = {
-    "get_killmail_killmail_hash" => "get_killmail",
-    "get_markets_groups_market_group" => "get_market_group",
-    "get_markets_groups" => "get_market_groups",
-    "get_character_corporationhistory" => "get_character_corporation_history",
-    "get_corporation_alliancehistory" => "get_corporation_alliance_history"
+    'get_killmail_killmail_hash' => 'get_killmail',
+    'get_markets_groups_market_group' => 'get_market_group',
+    'get_markets_groups' => 'get_market_groups',
+    'get_character_corporationhistory' => 'get_character_corporation_history',
+    'get_corporation_alliancehistory' => 'get_corporation_alliance_history'
   }
 
   error_mapping = {
-    400 => "ESI::Errors::BadRequestError",
-    401 => "ESI::Errors::UnauthorizedError",
-    403 => "ESI::Errors::ForbiddenError",
-    404 => "ESI::Errors::NotFoundError",
-    420 => "ESI::Errors::ErrorLimitedError",
-    422 => "ESI::Errors::UnprocessableEntityError",
-    500 => "ESI::Errors::InternalServerError",
-    503 => "ESI::Errors::ServiceUnavailableError",
-    504 => "ESI::Errors::GatewayTimeoutError",
-    520 => "ESI::Errors::EveServerError"
+    400 => 'ESI::Errors::BadRequestError',
+    401 => 'ESI::Errors::UnauthorizedError',
+    403 => 'ESI::Errors::ForbiddenError',
+    404 => 'ESI::Errors::NotFoundError',
+    420 => 'ESI::Errors::ErrorLimitedError',
+    422 => 'ESI::Errors::UnprocessableEntityError',
+    500 => 'ESI::Errors::InternalServerError',
+    503 => 'ESI::Errors::ServiceUnavailableError',
+    504 => 'ESI::Errors::GatewayTimeoutError',
+    520 => 'ESI::Errors::EveServerError'
   }.freeze
 
-  requires = []
-  includes = []
   all_operations.group_by { |(_, v)| v[:tag] }.each do |(tag, operations)|
-    lib_filename = "#{tag.gsub(/ /, "_").underscore}.rb"
-    module_name = tag.gsub(/ /, "_").classify
+    lib_filename = "#{tag.gsub(/ /, '_').underscore}.rb"
+    module_name = tag.gsub(/ /, '_').classify
     method_definitions = operations.sort_by { |(k, _v)| k }.each_with_object([]) do |(method_name, operation), a|
-      signature_params = operation[:params].map { |p| "#{p["name"]}:" }
-      raw_call_params = operation[:params].map { |p| "#{p["name"]}: #{p["name"]}" }
+      signature_params = operation[:params].map { |p| "#{p['name']}:" }
+      raw_call_params = operation[:params].map { |p| "#{p['name']}: #{p['name']}" }
 
       description = "# #{operation[:description]}"
-      description = "#{description}." unless description.end_with?(".")
+      description = "#{description}." unless description.end_with?('.')
       description += "\n"
 
       description += "#\n\n# This endpoint is cached for up to #{operation[:cache]} seconds.\n" if operation[:cache]
@@ -143,40 +141,40 @@ task :generate do
       end
 
       param_tags = operation[:params].map do |p|
-        "# @param #{p["name"]} [#{p["type"].capitalize}] #{p["description"]}"
+        "# @param #{p['name']} [#{p['type'].capitalize}] #{p['description']}"
       end
 
       if operation[:body]
         body_param = operation[:body]
-        body_name = body_param["name"]
+        body_name = body_param['name']
         body_type =
-          case body_param["schema"]["type"]
-          when "array"
-            "Array"
-          when "object"
-            "Hash"
+          case body_param['schema']['type']
+          when 'array'
+            'Array'
+          when 'object'
+            'Hash'
           end
 
         signature_params << "#{body_name}:"
         raw_call_params << "#{body_name}: #{body_name}"
-        param_tags += ["# @param #{body_name} [#{body_type}] #{body_param["description"]}"]
+        param_tags += ["# @param #{body_name} [#{body_type}] #{body_param['description']}"]
       end
 
       operation[:query]&.each do |p|
-        p_tag = "# @param #{p["name"]} [#{p["type"].capitalize}] "
-        p_tag += (p["description"]).to_s
-        p_tag += ". Must be one of: #{p["enum"].map { |e| "`#{e}`" }.join(", ")}" if p["enum"]
-        p_str = if p["default"] && p["type"] == "integer"
-                  "#{p["name"]}: #{p["default"]}"
-                elsif p["default"] && p["type"] == "string"
-                  "#{p["name"]}: \"#{p["default"]}\""
-                elsif !p["required"]
-                  "#{p["name"]}: nil"
+        p_tag = "# @param #{p['name']} [#{p['type'].capitalize}] "
+        p_tag += (p['description']).to_s
+        p_tag += ". Must be one of: #{p['enum'].map { |e| "`#{e}`" }.join(', ')}" if p['enum']
+        p_str = if p['default'] && p['type'] == 'integer'
+                  "#{p['name']}: #{p['default']}"
+                elsif p['default'] && p['type'] == 'string'
+                  "#{p['name']}: \"#{p['default']}\""
+                elsif !p['required']
+                  "#{p['name']}: nil"
                 else
-                  "#{p["name"]}:"
+                  "#{p['name']}:"
                 end
         signature_params << p_str
-        raw_call_params << "#{p["name"]}: #{p["name"]}"
+        raw_call_params << "#{p['name']}: #{p['name']}"
         param_tags << p_tag
       end
 
@@ -186,10 +184,10 @@ task :generate do
       raw_call_params += %w[headers params].map do |p|
         "#{p}: #{p}"
       end
-      param_tags << "# @param params [Hash] Additional query string parameters"
+      param_tags << '# @param params [Hash] Additional query string parameters'
 
       param_tags += [
-        "# @param headers [Hash] Additional headers"
+        '# @param headers [Hash] Additional headers'
       ]
       description += "#\n"
       description += param_tags.join("\n")
@@ -197,18 +195,18 @@ task :generate do
 
       description += "#\n"
       raise_tags = operation[:errors].map do |(e, v)|
-        "# @raise [#{error_mapping[e.to_i]}] #{v["description"]}"
+        "# @raise [#{error_mapping[e.to_i]}] #{v['description']}"
       end
       description += raise_tags.join("\n")
       description += "\n"
 
       description += "#\n"
       description += "# @see https://esi.evetech.net/ui/#/#{operation[:tag]}/#{operation[:name]}"
-      description.gsub!(/^$\n/m, "")
+      description.gsub!(/^$\n/m, '')
 
-      signature = "(#{signature_params.join(", ")})"
-      raw_call = "(#{raw_call_params.join(", ")})"
-      path_parts = operation[:path].split("/")
+      signature = "(#{signature_params.join(', ')})"
+      raw_call = "(#{raw_call_params.join(', ')})"
+      path_parts = operation[:path].split('/')
       path_parts.map! do |p|
         if p =~ /\{\w+\}/
           "##{p}"
@@ -216,18 +214,18 @@ task :generate do
           p
         end
       end
-      path = "#{path_parts.join("/")}/"
+      path = "#{path_parts.join('/')}/"
 
       http_call_params = %w[headers params].map { |p| "#{p}: #{p}" }
-      http_call_params << ("payload: #{body_param["name"]}" if operation[:body])
+      http_call_params << ("payload: #{body_param['name']}" if operation[:body])
 
       params_merge = if operation[:query].any?
-                       "params.merge!(#{operation[:query].map { |q| "'#{q["name"]}' => #{q["name"]}" }.join(", ")})"
+                       "params.merge!(#{operation[:query].map { |q| "'#{q['name']}' => #{q['name']}" }.join(', ')})"
                      else
-                       ""
+                       ''
                      end
 
-      http_call = "#{operation[:method]}(\"#{path}\", #{http_call_params.join(", ")})"
+      http_call = "#{operation[:method]}(\"#{path}\", #{http_call_params.join(', ')})"
 
       alias_methods = if method_aliases[method_name]
                         Array(method_aliases[method_name]).sort.map do |alias_name|
@@ -239,7 +237,7 @@ task :generate do
       alias_methods << "alias_method :#{operation[:name]}, :#{method_name}" unless operation[:name] == method_name
       alias_methods = alias_methods.join("\n")
 
-      if operation[:responses]["200"] && operation[:responses]["200"]["headers"] && operation[:responses]["200"]["headers"].key?("X-Pages")
+      if operation[:responses]['200'] && operation[:responses]['200']['headers'] && operation[:responses]['200']['headers'].key?('X-Pages')
         a << <<~METHOD_DEFINITION
           #{description}
           def #{method_name}#{signature}
@@ -258,7 +256,7 @@ task :generate do
         a << <<~METHOD_DEFINITION
           #{description}
           def #{method_name}#{signature}
-            #{method_name}_raw#{raw_call}.json
+            parse_response(#{method_name}_raw#{raw_call})
           end
           #{alias_methods}
 
@@ -286,43 +284,43 @@ task :generate do
 
     File.write(File.join("lib/esi/client/#{lib_filename}"), lib_content)
 
-    spec_filename = "#{tag.gsub(/ /, "_").underscore}_spec.rb"
+    spec_filename = "#{tag.gsub(/ /, '_').underscore}_spec.rb"
     spec_path = File.join("spec/lib/esi/client/#{spec_filename}")
 
     describe_blocks = operations.sort_by { |(k, _v)| k }.each_with_object([]) do |(method_name, operation), a|
-      success_path = operation[:path].gsub(/\{\w+\}/, "1234567890")
-      success_response = operation[:responses].find { |(k, _)| k.start_with?("20") }
+      success_path = operation[:path].gsub(/\{\w+\}/, '1234567890')
+      success_response = operation[:responses].find { |(k, _)| k.start_with?('20') }
       success_code = success_response.first
       success_desc = success_response.last
 
       success_response_body = case success_code
-                              when "204"
-                                "nil"
+                              when '204'
+                                'nil'
                               else
-                                success_desc["examples"]["application/json"].inspect
+                                success_desc['examples']['application/json'].inspect
                               end
 
-      success_params = operation[:params].map { |p| "#{p["name"]}: \"1234567890\"" }
-      success_params += operation[:query].map { |p| "#{p["name"]}: \"1234567890\"" }
+      success_params = operation[:params].map { |p| "#{p['name']}: \"1234567890\"" }
+      success_params += operation[:query].map { |p| "#{p['name']}: \"1234567890\"" }
 
       if operation[:body]
         body_param = operation[:body]
-        body_name = body_param["name"]
+        body_name = body_param['name']
         body_value =
-          case body_param["schema"]["type"]
-          when "array"
-            "[1, 2, 3]"
-          when "object"
+          case body_param['schema']['type']
+          when 'array'
+            '[1, 2, 3]'
+          when 'object'
             '{ "foo" => "bar" }'
           end
         success_params << "#{body_name}: #{body_value}"
       end
 
-      with_query = operation[:query].any? ? ".with(query: { #{operation[:query].map { |p| "#{p["name"]}: \"1234567890\"" }.join(", ")} })" : ""
+      with_query = operation[:query].any? ? ".with(query: { #{operation[:query].map { |p| "#{p['name']}: \"1234567890\"" }.join(', ')} })" : ''
 
-      extra_headers = success_desc["headers"] && success_desc["headers"]["X-Pages"] ? ", 'X-Pages': '1'" : ""
+      extra_headers = success_desc['headers'] && success_desc['headers']['X-Pages'] ? ", 'X-Pages': '1'" : ''
 
-      describe = "  describe \"##{method_name}\" do\n"
+      describe =  "  describe \"##{method_name}\" do\n"
       describe += "    context \"when the response is #{success_code}\" do\n"
       describe += "      let(:response) { #{success_response_body} }\n"
       describe += "\n"
@@ -331,33 +329,10 @@ task :generate do
       describe += "      end\n"
       describe += "\n"
       describe += "      it \"returns the response\" do\n"
-      describe += "        expect(client.#{method_name}(#{success_params.join(", ")})).to eq(response)\n"
+      describe += "        expect(client.#{method_name}(#{success_params.join(', ')})).to eq(response)\n"
       describe += "      end\n"
       describe += "    end\n"
-
-      describe += "\n"
-
-      error_contexts = operation[:errors].map do |(code, error)|
-        next if %w[502 503 504].include?(code)
-
-        error_response_body = error["examples"]["application/json"].inspect
-
-        context = "    context \"when the response is #{code}\" do\n"
-        context += "      let(:response) { #{error_response_body} }\n"
-        context += "\n"
-        context += "      before do\n"
-        context += "        stub_request(:#{operation[:method]}, \"https://esi.evetech.net/latest#{success_path}\")#{with_query}.to_return(body: response.to_json, status: #{code}, headers: { 'Content-Type': 'application/json' })\n"
-        context += "      end\n"
-        context += "\n"
-        context += "      it \"raises a #{error_mapping[code.to_i]} error\" do\n"
-        context += "        expect { client.#{method_name}(#{success_params.join(", ")}) }.to raise_error(#{error_mapping[code.to_i]})\n"
-        context += "      end\n"
-        "#{context}    end\n"
-      end
-
-      describe += error_contexts.join("\n")
-
-      describe += "  end"
+      describe += '  end'
       a << describe
     end
 
@@ -365,22 +340,14 @@ task :generate do
       # frozen_string_literal: true
 
       RSpec.describe ESI::Client::#{module_name}, type: :stub do
-        subject(:client) { ESI::Client.new(user_agent: \"esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)\") }
+        subject(:client) { ESI::Client.new(retries: 2, user_agent: \"esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)\") }
 
       #{describe_blocks.join("\n\n")}
       end
     SPEC_FILE
 
     File.write(spec_path, spec_content)
-
-    requires << "require_relative \"./client/#{lib_filename.gsub(/\.rb/, "")}\""
-    includes << "include ESI::Client::#{module_name}"
   end
 
-  at_exit do
-    puts requires
-    puts includes
-  end
-
-  Rake::Task["rubocop:auto_correct"].invoke
+  Rake::Task['rubocop:auto_correct'].invoke
 end

--- a/bin/console
+++ b/bin/console
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "bundler/setup"
-require "esi-sdk"
+require 'bundler/setup'
+require 'esi-sdk'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -11,5 +11,5 @@ require "esi-sdk"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/esi-sdk.gemspec
+++ b/esi-sdk.gemspec
@@ -1,31 +1,32 @@
 # frozen_string_literal: true
 
-require_relative "./lib/esi/version"
+require_relative './lib/esi/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "esi-sdk"
+  spec.name          = 'esi-sdk'
   spec.version       = ESI::VERSION
-  spec.authors       = ["Bokobo Shahni"]
-  spec.email         = ["shahni@bokobo.space"]
+  spec.authors       = ['Bokobo Shahni']
+  spec.email         = ['shahni@bokobo.space']
 
-  spec.summary       = "API client for the EVE Swagger Interface (ESI)"
-  spec.description   = "ESI SDK is a Ruby API client for the EVE Swagger Interface (ESI), "\
-                       "the official API for the EVE Online MMORPG."
-  spec.homepage      = "https://github.com/bokoboshahni/esi-sdk"
-  spec.license       = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.summary       = 'API client for the EVE Swagger Interface (ESI)'
+  spec.description   = 'ESI SDK is a Ruby API client for the EVE Swagger Interface (ESI), '\
+                       'the official API for the EVE Online MMORPG.'
+  spec.homepage      = 'https://github.com/bokoboshahni/esi-sdk'
+  spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 3.0.0'
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/bokoboshahni/esi-sdk"
-  spec.metadata["changelog_uri"] = "https://github.com/bokoboshahni/blob/main/CHANGELOG.md"
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/bokoboshahni/esi-sdk'
+  spec.metadata['changelog_uri'] = 'https://github.com/bokoboshahni/blob/main/CHANGELOG.md'
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "httpx", "~> 0.18"
-  spec.add_dependency "retriable", "~> 3.1"
+  spec.add_dependency 'oj', '~> 3.13'
+  spec.add_dependency 'retriable', '~> 3.1'
+  spec.add_dependency 'typhoeus', '~> 1.4'
 end

--- a/exe/esi-sdk
+++ b/exe/esi-sdk
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "esi/sdk"
+require 'esi/sdk'

--- a/lib/esi-sdk.rb
+++ b/lib/esi-sdk.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "./esi/client"
-require_relative "./esi/version"
+require_relative './esi/client'
+require_relative './esi/version'
 
 # Namespace for the EVE Swagger Interface (ESI) SDK.
 module ESI

--- a/lib/esi/client/alliance.rb
+++ b/lib/esi/client/alliance.rb
@@ -26,7 +26,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Alliance/get_alliances_alliance_id
       def get_alliance(alliance_id:, headers: {}, params: {})
-        get_alliance_raw(alliance_id: alliance_id, headers: headers, params: params).json
+        parse_response(get_alliance_raw(alliance_id: alliance_id, headers: headers, params: params))
       end
       alias get_alliances_alliance_id get_alliance
 
@@ -76,7 +76,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Alliance/get_alliances_alliance_id_corporations
       def get_alliance_corporations(alliance_id:, headers: {}, params: {})
-        get_alliance_corporations_raw(alliance_id: alliance_id, headers: headers, params: params).json
+        parse_response(get_alliance_corporations_raw(alliance_id: alliance_id, headers: headers, params: params))
       end
       alias get_alliances_alliance_id_corporations get_alliance_corporations
 
@@ -122,7 +122,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Alliance/get_alliances_alliance_id_icons
       def get_alliance_icons(alliance_id:, headers: {}, params: {})
-        get_alliance_icons_raw(alliance_id: alliance_id, headers: headers, params: params).json
+        parse_response(get_alliance_icons_raw(alliance_id: alliance_id, headers: headers, params: params))
       end
       alias get_alliances_alliance_id_icons get_alliance_icons
 
@@ -167,7 +167,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Alliance/get_alliances
       def get_alliances(headers: {}, params: {})
-        get_alliances_raw(headers: headers, params: params).json
+        parse_response(get_alliances_raw(headers: headers, params: params))
       end
 
       # List all active player alliances.
@@ -190,7 +190,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Alliance/get_alliances
       def get_alliances_raw(headers: {}, params: {})
-        get("/alliances/", headers: headers, params: params)
+        get('/alliances/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/assets.rb
+++ b/lib/esi/client/assets.rb
@@ -144,7 +144,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Assets/post_characters_character_id_assets_locations
       def post_character_asset_locations(character_id:, item_ids:, headers: {}, params: {})
-        post_character_asset_locations_raw(character_id: character_id, item_ids: item_ids, headers: headers, params: params).json
+        parse_response(post_character_asset_locations_raw(character_id: character_id, item_ids: item_ids, headers: headers, params: params))
       end
       alias post_characters_character_id_assets_locations post_character_asset_locations
 
@@ -200,7 +200,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Assets/post_characters_character_id_assets_names
       def post_character_asset_names(character_id:, item_ids:, headers: {}, params: {})
-        post_character_asset_names_raw(character_id: character_id, item_ids: item_ids, headers: headers, params: params).json
+        parse_response(post_character_asset_names_raw(character_id: character_id, item_ids: item_ids, headers: headers, params: params))
       end
       alias post_characters_character_id_assets_names post_character_asset_names
 
@@ -257,7 +257,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Assets/post_corporations_corporation_id_assets_locations
       def post_corporation_asset_locations(corporation_id:, item_ids:, headers: {}, params: {})
-        post_corporation_asset_locations_raw(corporation_id: corporation_id, item_ids: item_ids, headers: headers, params: params).json
+        parse_response(post_corporation_asset_locations_raw(corporation_id: corporation_id, item_ids: item_ids, headers: headers, params: params))
       end
       alias post_corporations_corporation_id_assets_locations post_corporation_asset_locations
 
@@ -315,7 +315,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Assets/post_corporations_corporation_id_assets_names
       def post_corporation_asset_names(corporation_id:, item_ids:, headers: {}, params: {})
-        post_corporation_asset_names_raw(corporation_id: corporation_id, item_ids: item_ids, headers: headers, params: params).json
+        parse_response(post_corporation_asset_names_raw(corporation_id: corporation_id, item_ids: item_ids, headers: headers, params: params))
       end
       alias post_corporations_corporation_id_assets_names post_corporation_asset_names
 

--- a/lib/esi/client/calendar.rb
+++ b/lib/esi/client/calendar.rb
@@ -32,7 +32,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Calendar/get_characters_character_id_calendar
       def get_character_calendar(character_id:, from_event: nil, headers: {}, params: {})
-        get_character_calendar_raw(character_id: character_id, from_event: from_event, headers: headers, params: params).json
+        parse_response(get_character_calendar_raw(character_id: character_id, from_event: from_event, headers: headers, params: params))
       end
       alias get_characters_character_id_calendar get_character_calendar
 
@@ -64,7 +64,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Calendar/get_characters_character_id_calendar
       def get_character_calendar_raw(character_id:, from_event: nil, headers: {}, params: {})
-        params.merge!("from_event" => from_event)
+        params.merge!('from_event' => from_event)
         get("/characters/#{character_id}/calendar/", headers: headers, params: params)
       end
 
@@ -97,7 +97,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Calendar/get_characters_character_id_calendar_event_id
       def get_character_calendar_event(character_id:, event_id:, headers: {}, params: {})
-        get_character_calendar_event_raw(character_id: character_id, event_id: event_id, headers: headers, params: params).json
+        parse_response(get_character_calendar_event_raw(character_id: character_id, event_id: event_id, headers: headers, params: params))
       end
       alias get_characters_character_id_calendar_event_id get_character_calendar_event
 
@@ -162,7 +162,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Calendar/get_characters_character_id_calendar_event_id_attendees
       def get_character_calendar_event_attendees(character_id:, event_id:, headers: {}, params: {})
-        get_character_calendar_event_attendees_raw(character_id: character_id, event_id: event_id, headers: headers, params: params).json
+        parse_response(get_character_calendar_event_attendees_raw(character_id: character_id, event_id: event_id, headers: headers, params: params))
       end
       alias get_characters_character_id_calendar_event_id_attendees get_character_calendar_event_attendees
 
@@ -227,7 +227,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Calendar/put_characters_character_id_calendar_event_id
       def put_character_calendar_event(character_id:, event_id:, response:, headers: {}, params: {})
-        put_character_calendar_event_raw(character_id: character_id, event_id: event_id, response: response, headers: headers, params: params).json
+        parse_response(put_character_calendar_event_raw(character_id: character_id, event_id: event_id, response: response, headers: headers, params: params))
       end
       alias put_characters_character_id_calendar_event_id put_character_calendar_event
 

--- a/lib/esi/client/character.rb
+++ b/lib/esi/client/character.rb
@@ -9,6 +9,7 @@ module ESI
       # This endpoint is cached for up to 86400 seconds.
       #
       # @esi_version dev
+      # @esi_version legacy
       # @esi_version v5
       #
       # @param character_id [Integer] An EVE character ID
@@ -24,7 +25,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id
       def get_character(character_id:, headers: {}, params: {})
-        get_character_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id get_character
 
@@ -33,6 +34,7 @@ module ESI
       # This endpoint is cached for up to 86400 seconds.
       #
       # @esi_version dev
+      # @esi_version legacy
       # @esi_version v5
       #
       # @param character_id [Integer] An EVE character ID
@@ -76,7 +78,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_agents_research
       def get_character_agents_research(character_id:, headers: {}, params: {})
-        get_character_agents_research_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_agents_research_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_agents_research get_character_agents_research
 
@@ -184,7 +186,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_corporationhistory
       def get_character_corporationhistory(character_id:, headers: {}, params: {})
-        get_character_corporationhistory_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_corporationhistory_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_character_corporation_history get_character_corporationhistory
       alias get_characters_character_id_corporationhistory get_character_corporationhistory
@@ -236,7 +238,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_fatigue
       def get_character_fatigue(character_id:, headers: {}, params: {})
-        get_character_fatigue_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_fatigue_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_fatigue get_character_fatigue
 
@@ -293,7 +295,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_medals
       def get_character_medals(character_id:, headers: {}, params: {})
-        get_character_medals_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_medals_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_medals get_character_medals
 
@@ -350,7 +352,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_notifications_contacts
       def get_character_notification_contacts(character_id:, headers: {}, params: {})
-        get_character_notification_contacts_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_notification_contacts_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_notifications_contacts get_character_notification_contacts
 
@@ -408,7 +410,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_notifications
       def get_character_notifications(character_id:, headers: {}, params: {})
-        get_character_notifications_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_notifications_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_notifications get_character_notifications
 
@@ -460,7 +462,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_portrait
       def get_character_portrait(character_id:, headers: {}, params: {})
-        get_character_portrait_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_portrait_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_portrait get_character_portrait
 
@@ -511,7 +513,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_roles
       def get_character_roles(character_id:, headers: {}, params: {})
-        get_character_roles_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_roles_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_roles get_character_roles
 
@@ -568,7 +570,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_standings
       def get_character_standings(character_id:, headers: {}, params: {})
-        get_character_standings_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_standings_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_standings get_character_standings
 
@@ -625,7 +627,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/get_characters_character_id_titles
       def get_character_titles(character_id:, headers: {}, params: {})
-        get_character_titles_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_titles_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_titles get_character_titles
 
@@ -681,7 +683,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/post_characters_character_id_cspa
       def post_character_cspa(character_id:, characters:, headers: {}, params: {})
-        post_character_cspa_raw(character_id: character_id, characters: characters, headers: headers, params: params).json
+        parse_response(post_character_cspa_raw(character_id: character_id, characters: characters, headers: headers, params: params))
       end
       alias post_characters_character_id_cspa post_character_cspa
 
@@ -731,7 +733,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/post_characters_affiliation
       def post_characters_affiliation(characters:, headers: {}, params: {})
-        post_characters_affiliation_raw(characters: characters, headers: headers, params: params).json
+        parse_response(post_characters_affiliation_raw(characters: characters, headers: headers, params: params))
       end
 
       # Bulk lookup of character IDs to corporation, alliance and faction.
@@ -753,7 +755,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Character/post_characters_affiliation
       def post_characters_affiliation_raw(characters:, headers: {}, params: {})
-        post("/characters/affiliation/", headers: headers, params: params, payload: characters)
+        post('/characters/affiliation/', headers: headers, params: params, payload: characters)
       end
     end
   end

--- a/lib/esi/client/clones.rb
+++ b/lib/esi/client/clones.rb
@@ -30,7 +30,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Clones/get_characters_character_id_clones
       def get_character_clones(character_id:, headers: {}, params: {})
-        get_character_clones_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_clones_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_clones get_character_clones
 
@@ -90,7 +90,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Clones/get_characters_character_id_implants
       def get_character_implants(character_id:, headers: {}, params: {})
-        get_character_implants_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_implants_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_implants get_character_implants
 

--- a/lib/esi/client/contacts.rb
+++ b/lib/esi/client/contacts.rb
@@ -28,7 +28,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/delete_characters_character_id_contacts
       def delete_character_contacts(character_id:, contact_ids:, headers: {}, params: {})
-        delete_character_contacts_raw(character_id: character_id, contact_ids: contact_ids, headers: headers, params: params).json
+        parse_response(delete_character_contacts_raw(character_id: character_id, contact_ids: contact_ids, headers: headers, params: params))
       end
       alias delete_characters_character_id_contacts delete_character_contacts
 
@@ -56,7 +56,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/delete_characters_character_id_contacts
       def delete_character_contacts_raw(character_id:, contact_ids:, headers: {}, params: {})
-        params.merge!("contact_ids" => contact_ids)
+        params.merge!('contact_ids' => contact_ids)
         delete("/characters/#{character_id}/contacts/", headers: headers, params: params)
       end
 
@@ -86,7 +86,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/get_alliances_alliance_id_contacts_labels
       def get_alliance_contact_labels(alliance_id:, headers: {}, params: {})
-        get_alliance_contact_labels_raw(alliance_id: alliance_id, headers: headers, params: params).json
+        parse_response(get_alliance_contact_labels_raw(alliance_id: alliance_id, headers: headers, params: params))
       end
       alias get_alliances_alliance_id_contacts_labels get_alliance_contact_labels
 
@@ -202,7 +202,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/get_characters_character_id_contacts_labels
       def get_character_contact_labels(character_id:, headers: {}, params: {})
-        get_character_contact_labels_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_contact_labels_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_contacts_labels get_character_contact_labels
 
@@ -318,7 +318,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/get_corporations_corporation_id_contacts_labels
       def get_corporation_contact_labels(corporation_id:, headers: {}, params: {})
-        get_corporation_contact_labels_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_contact_labels_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_contacts_labels get_corporation_contact_labels
 
@@ -436,7 +436,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/post_characters_character_id_contacts
       def post_character_contacts(character_id:, contact_ids:, standing:, label_ids: nil, watched: nil, headers: {}, params: {})
-        post_character_contacts_raw(character_id: character_id, contact_ids: contact_ids, label_ids: label_ids, standing: standing, watched: watched, headers: headers, params: params).json
+        parse_response(post_character_contacts_raw(character_id: character_id, contact_ids: contact_ids, label_ids: label_ids, standing: standing, watched: watched, headers: headers, params: params))
       end
       alias post_characters_character_id_contacts post_character_contacts
 
@@ -468,7 +468,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/post_characters_character_id_contacts
       def post_character_contacts_raw(character_id:, contact_ids:, standing:, label_ids: nil, watched: nil, headers: {}, params: {})
-        params.merge!("label_ids" => label_ids, "standing" => standing, "watched" => watched)
+        params.merge!('label_ids' => label_ids, 'standing' => standing, 'watched' => watched)
         post("/characters/#{character_id}/contacts/", headers: headers, params: params, payload: contact_ids)
       end
 
@@ -499,7 +499,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/put_characters_character_id_contacts
       def put_character_contacts(character_id:, contact_ids:, standing:, label_ids: nil, watched: nil, headers: {}, params: {})
-        put_character_contacts_raw(character_id: character_id, contact_ids: contact_ids, label_ids: label_ids, standing: standing, watched: watched, headers: headers, params: params).json
+        parse_response(put_character_contacts_raw(character_id: character_id, contact_ids: contact_ids, label_ids: label_ids, standing: standing, watched: watched, headers: headers, params: params))
       end
       alias put_characters_character_id_contacts put_character_contacts
 
@@ -530,7 +530,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contacts/put_characters_character_id_contacts
       def put_character_contacts_raw(character_id:, contact_ids:, standing:, label_ids: nil, watched: nil, headers: {}, params: {})
-        params.merge!("label_ids" => label_ids, "standing" => standing, "watched" => watched)
+        params.merge!('label_ids' => label_ids, 'standing' => standing, 'watched' => watched)
         put("/characters/#{character_id}/contacts/", headers: headers, params: params, payload: contact_ids)
       end
     end

--- a/lib/esi/client/contracts.rb
+++ b/lib/esi/client/contracts.rb
@@ -32,7 +32,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contracts/get_characters_character_id_contracts_contract_id_bids
       def get_character_contract_bids(character_id:, contract_id:, headers: {}, params: {})
-        get_character_contract_bids_raw(character_id: character_id, contract_id: contract_id, headers: headers, params: params).json
+        parse_response(get_character_contract_bids_raw(character_id: character_id, contract_id: contract_id, headers: headers, params: params))
       end
       alias get_characters_character_id_contracts_contract_id_bids get_character_contract_bids
 
@@ -95,7 +95,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contracts/get_characters_character_id_contracts_contract_id_items
       def get_character_contract_items(character_id:, contract_id:, headers: {}, params: {})
-        get_character_contract_items_raw(character_id: character_id, contract_id: contract_id, headers: headers, params: params).json
+        parse_response(get_character_contract_items_raw(character_id: character_id, contract_id: contract_id, headers: headers, params: params))
       end
       alias get_characters_character_id_contracts_contract_id_items get_character_contract_items
 
@@ -432,7 +432,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Contracts/get_corporations_corporation_id_contracts_contract_id_items
       def get_corporation_contract_items(contract_id:, corporation_id:, headers: {}, params: {})
-        get_corporation_contract_items_raw(contract_id: contract_id, corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_contract_items_raw(contract_id: contract_id, corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_contracts_contract_id_items get_corporation_contract_items
 

--- a/lib/esi/client/corporation.rb
+++ b/lib/esi/client/corporation.rb
@@ -24,7 +24,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id
       def get_corporation(corporation_id:, headers: {}, params: {})
-        get_corporation_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id get_corporation
 
@@ -70,7 +70,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_alliancehistory
       def get_corporation_alliancehistory(corporation_id:, headers: {}, params: {})
-        get_corporation_alliancehistory_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_alliancehistory_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporation_alliance_history get_corporation_alliancehistory
       alias get_corporations_corporation_id_alliancehistory get_corporation_alliancehistory
@@ -236,7 +236,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_divisions
       def get_corporation_divisions(corporation_id:, headers: {}, params: {})
-        get_corporation_divisions_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_divisions_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_divisions get_corporation_divisions
 
@@ -293,7 +293,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_facilities
       def get_corporation_facilities(corporation_id:, headers: {}, params: {})
-        get_corporation_facilities_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_facilities_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_facilities get_corporation_facilities
 
@@ -345,7 +345,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_icons
       def get_corporation_icons(corporation_id:, headers: {}, params: {})
-        get_corporation_icons_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_icons_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_icons get_corporation_icons
 
@@ -511,7 +511,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_members_titles
       def get_corporation_member_titles(corporation_id:, headers: {}, params: {})
-        get_corporation_member_titles_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_member_titles_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_members_titles get_corporation_member_titles
 
@@ -568,7 +568,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_members
       def get_corporation_members(corporation_id:, headers: {}, params: {})
-        get_corporation_members_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_members_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_members get_corporation_members
 
@@ -625,7 +625,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_members_limit
       def get_corporation_members_limit(corporation_id:, headers: {}, params: {})
-        get_corporation_members_limit_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_members_limit_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_members_limit get_corporation_members_limit
 
@@ -682,7 +682,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_membertracking
       def get_corporation_membertracking(corporation_id:, headers: {}, params: {})
-        get_corporation_membertracking_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_membertracking_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_membertracking get_corporation_membertracking
 
@@ -730,7 +730,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_npccorps
       def get_corporation_npccorps(headers: {}, params: {})
-        get_corporation_npccorps_raw(headers: headers, params: params).json
+        parse_response(get_corporation_npccorps_raw(headers: headers, params: params))
       end
       alias get_corporations_npccorps get_corporation_npccorps
 
@@ -750,7 +750,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_npccorps
       def get_corporation_npccorps_raw(headers: {}, params: {})
-        get("/corporations/npccorps/", headers: headers, params: params)
+        get('/corporations/npccorps/', headers: headers, params: params)
       end
 
       # Return the roles of all members if the character has the personnel manager role or any grantable role.
@@ -778,7 +778,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_roles
       def get_corporation_roles(corporation_id:, headers: {}, params: {})
-        get_corporation_roles_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_roles_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_roles get_corporation_roles
 
@@ -1010,7 +1010,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_starbases_starbase_id
       def get_corporation_starbase(corporation_id:, starbase_id:, system_id:, headers: {}, params: {})
-        get_corporation_starbase_raw(corporation_id: corporation_id, starbase_id: starbase_id, system_id: system_id, headers: headers, params: params).json
+        parse_response(get_corporation_starbase_raw(corporation_id: corporation_id, starbase_id: starbase_id, system_id: system_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_starbases_starbase_id get_corporation_starbase
 
@@ -1041,7 +1041,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_starbases_starbase_id
       def get_corporation_starbase_raw(corporation_id:, starbase_id:, system_id:, headers: {}, params: {})
-        params.merge!("system_id" => system_id)
+        params.merge!('system_id' => system_id)
         get("/corporations/#{corporation_id}/starbases/#{starbase_id}/", headers: headers, params: params)
       end
 
@@ -1184,7 +1184,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Corporation/get_corporations_corporation_id_titles
       def get_corporation_titles(corporation_id:, headers: {}, params: {})
-        get_corporation_titles_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_titles_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_titles get_corporation_titles
 

--- a/lib/esi/client/dogma.rb
+++ b/lib/esi/client/dogma.rb
@@ -23,7 +23,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Dogma/get_dogma_attributes_attribute_id
       def get_dogma_attribute(attribute_id:, headers: {}, params: {})
-        get_dogma_attribute_raw(attribute_id: attribute_id, headers: headers, params: params).json
+        parse_response(get_dogma_attribute_raw(attribute_id: attribute_id, headers: headers, params: params))
       end
       alias get_dogma_attributes_attribute_id get_dogma_attribute
 
@@ -66,7 +66,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Dogma/get_dogma_attributes
       def get_dogma_attributes(headers: {}, params: {})
-        get_dogma_attributes_raw(headers: headers, params: params).json
+        parse_response(get_dogma_attributes_raw(headers: headers, params: params))
       end
 
       # Get a list of dogma attribute ids.
@@ -86,7 +86,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Dogma/get_dogma_attributes
       def get_dogma_attributes_raw(headers: {}, params: {})
-        get("/dogma/attributes/", headers: headers, params: params)
+        get('/dogma/attributes/', headers: headers, params: params)
       end
 
       # Returns info about a dynamic item resulting from mutation with a mutaplasmid.
@@ -109,7 +109,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Dogma/get_dogma_dynamic_items_type_id_item_id
       def get_dogma_dynamic_items_type_item(item_id:, type_id:, headers: {}, params: {})
-        get_dogma_dynamic_items_type_item_raw(item_id: item_id, type_id: type_id, headers: headers, params: params).json
+        parse_response(get_dogma_dynamic_items_type_item_raw(item_id: item_id, type_id: type_id, headers: headers, params: params))
       end
       alias get_dogma_dynamic_items_type_id_item_id get_dogma_dynamic_items_type_item
 
@@ -154,7 +154,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Dogma/get_dogma_effects_effect_id
       def get_dogma_effect(effect_id:, headers: {}, params: {})
-        get_dogma_effect_raw(effect_id: effect_id, headers: headers, params: params).json
+        parse_response(get_dogma_effect_raw(effect_id: effect_id, headers: headers, params: params))
       end
       alias get_dogma_effects_effect_id get_dogma_effect
 
@@ -196,7 +196,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Dogma/get_dogma_effects
       def get_dogma_effects(headers: {}, params: {})
-        get_dogma_effects_raw(headers: headers, params: params).json
+        parse_response(get_dogma_effects_raw(headers: headers, params: params))
       end
 
       # Get a list of dogma effect ids.
@@ -216,7 +216,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Dogma/get_dogma_effects
       def get_dogma_effects_raw(headers: {}, params: {})
-        get("/dogma/effects/", headers: headers, params: params)
+        get('/dogma/effects/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/faction_warfare.rb
+++ b/lib/esi/client/faction_warfare.rb
@@ -29,7 +29,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_characters_character_id_fw_stats
       def get_character_fw_stats(character_id:, headers: {}, params: {})
-        get_character_fw_stats_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_fw_stats_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_fw_stats get_character_fw_stats
 
@@ -86,7 +86,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_corporations_corporation_id_fw_stats
       def get_corporation_fw_stats(corporation_id:, headers: {}, params: {})
-        get_corporation_fw_stats_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_fw_stats_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_fw_stats get_corporation_fw_stats
 
@@ -136,7 +136,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_leaderboards_characters
       def get_fw_leaderboard_characters(headers: {}, params: {})
-        get_fw_leaderboard_characters_raw(headers: headers, params: params).json
+        parse_response(get_fw_leaderboard_characters_raw(headers: headers, params: params))
       end
       alias get_fw_leaderboards_characters get_fw_leaderboard_characters
 
@@ -158,7 +158,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_leaderboards_characters
       def get_fw_leaderboard_characters_raw(headers: {}, params: {})
-        get("/fw/leaderboards/characters/", headers: headers, params: params)
+        get('/fw/leaderboards/characters/', headers: headers, params: params)
       end
 
       # Top 10 leaderboard of corporations for kills and victory points separated by total, last week and yesterday.
@@ -179,7 +179,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_leaderboards_corporations
       def get_fw_leaderboard_corporations(headers: {}, params: {})
-        get_fw_leaderboard_corporations_raw(headers: headers, params: params).json
+        parse_response(get_fw_leaderboard_corporations_raw(headers: headers, params: params))
       end
       alias get_fw_leaderboards_corporations get_fw_leaderboard_corporations
 
@@ -201,7 +201,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_leaderboards_corporations
       def get_fw_leaderboard_corporations_raw(headers: {}, params: {})
-        get("/fw/leaderboards/corporations/", headers: headers, params: params)
+        get('/fw/leaderboards/corporations/', headers: headers, params: params)
       end
 
       # Top 4 leaderboard of factions for kills and victory points separated by total, last week and yesterday.
@@ -222,7 +222,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_leaderboards
       def get_fw_leaderboards(headers: {}, params: {})
-        get_fw_leaderboards_raw(headers: headers, params: params).json
+        parse_response(get_fw_leaderboards_raw(headers: headers, params: params))
       end
 
       # Top 4 leaderboard of factions for kills and victory points separated by total, last week and yesterday.
@@ -243,7 +243,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_leaderboards
       def get_fw_leaderboards_raw(headers: {}, params: {})
-        get("/fw/leaderboards/", headers: headers, params: params)
+        get('/fw/leaderboards/', headers: headers, params: params)
       end
 
       # Statistical overviews of factions involved in faction warfare.
@@ -264,7 +264,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_stats
       def get_fw_stats(headers: {}, params: {})
-        get_fw_stats_raw(headers: headers, params: params).json
+        parse_response(get_fw_stats_raw(headers: headers, params: params))
       end
 
       # Statistical overviews of factions involved in faction warfare.
@@ -285,7 +285,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_stats
       def get_fw_stats_raw(headers: {}, params: {})
-        get("/fw/stats/", headers: headers, params: params)
+        get('/fw/stats/', headers: headers, params: params)
       end
 
       # An overview of the current ownership of faction warfare solar systems.
@@ -308,7 +308,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_systems
       def get_fw_systems(headers: {}, params: {})
-        get_fw_systems_raw(headers: headers, params: params).json
+        parse_response(get_fw_systems_raw(headers: headers, params: params))
       end
 
       # An overview of the current ownership of faction warfare solar systems.
@@ -331,7 +331,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_systems
       def get_fw_systems_raw(headers: {}, params: {})
-        get("/fw/systems/", headers: headers, params: params)
+        get('/fw/systems/', headers: headers, params: params)
       end
 
       # Data about which NPC factions are at war.
@@ -352,7 +352,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_wars
       def get_fw_wars(headers: {}, params: {})
-        get_fw_wars_raw(headers: headers, params: params).json
+        parse_response(get_fw_wars_raw(headers: headers, params: params))
       end
 
       # Data about which NPC factions are at war.
@@ -373,7 +373,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Faction Warfare/get_fw_wars
       def get_fw_wars_raw(headers: {}, params: {})
-        get("/fw/wars/", headers: headers, params: params)
+        get('/fw/wars/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/fittings.rb
+++ b/lib/esi/client/fittings.rb
@@ -29,7 +29,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fittings/delete_characters_character_id_fittings_fitting_id
       def delete_character_fitting(character_id:, fitting_id:, headers: {}, params: {})
-        delete_character_fitting_raw(character_id: character_id, fitting_id: fitting_id, headers: headers, params: params).json
+        parse_response(delete_character_fitting_raw(character_id: character_id, fitting_id: fitting_id, headers: headers, params: params))
       end
       alias delete_characters_character_id_fittings_fitting_id delete_character_fitting
 
@@ -86,7 +86,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fittings/get_characters_character_id_fittings
       def get_character_fittings(character_id:, headers: {}, params: {})
-        get_character_fittings_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_fittings_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_fittings get_character_fittings
 
@@ -142,7 +142,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fittings/post_characters_character_id_fittings
       def post_character_fittings(character_id:, fitting:, headers: {}, params: {})
-        post_character_fittings_raw(character_id: character_id, fitting: fitting, headers: headers, params: params).json
+        parse_response(post_character_fittings_raw(character_id: character_id, fitting: fitting, headers: headers, params: params))
       end
       alias post_characters_character_id_fittings post_character_fittings
 

--- a/lib/esi/client/fleets.rb
+++ b/lib/esi/client/fleets.rb
@@ -30,7 +30,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/delete_fleets_fleet_id_members_member_id
       def delete_fleet_member(fleet_id:, member_id:, headers: {}, params: {})
-        delete_fleet_member_raw(fleet_id: fleet_id, member_id: member_id, headers: headers, params: params).json
+        parse_response(delete_fleet_member_raw(fleet_id: fleet_id, member_id: member_id, headers: headers, params: params))
       end
       alias delete_fleets_fleet_id_members_member_id delete_fleet_member
 
@@ -89,7 +89,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/delete_fleets_fleet_id_squads_squad_id
       def delete_fleet_squad(fleet_id:, squad_id:, headers: {}, params: {})
-        delete_fleet_squad_raw(fleet_id: fleet_id, squad_id: squad_id, headers: headers, params: params).json
+        parse_response(delete_fleet_squad_raw(fleet_id: fleet_id, squad_id: squad_id, headers: headers, params: params))
       end
       alias delete_fleets_fleet_id_squads_squad_id delete_fleet_squad
 
@@ -148,7 +148,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/delete_fleets_fleet_id_wings_wing_id
       def delete_fleet_wing(fleet_id:, wing_id:, headers: {}, params: {})
-        delete_fleet_wing_raw(fleet_id: fleet_id, wing_id: wing_id, headers: headers, params: params).json
+        parse_response(delete_fleet_wing_raw(fleet_id: fleet_id, wing_id: wing_id, headers: headers, params: params))
       end
       alias delete_fleets_fleet_id_wings_wing_id delete_fleet_wing
 
@@ -207,7 +207,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/get_characters_character_id_fleet
       def get_character_fleet(character_id:, headers: {}, params: {})
-        get_character_fleet_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_fleet_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_fleet get_character_fleet
 
@@ -267,7 +267,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/get_fleets_fleet_id
       def get_fleet(fleet_id:, headers: {}, params: {})
-        get_fleet_raw(fleet_id: fleet_id, headers: headers, params: params).json
+        parse_response(get_fleet_raw(fleet_id: fleet_id, headers: headers, params: params))
       end
       alias get_fleets_fleet_id get_fleet
 
@@ -328,7 +328,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/get_fleets_fleet_id_members
       def get_fleet_members(fleet_id:, headers: {}, params: {})
-        get_fleet_members_raw(fleet_id: fleet_id, headers: headers, params: params).json
+        parse_response(get_fleet_members_raw(fleet_id: fleet_id, headers: headers, params: params))
       end
       alias get_fleets_fleet_id_members get_fleet_members
 
@@ -389,7 +389,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/get_fleets_fleet_id_wings
       def get_fleet_wings(fleet_id:, headers: {}, params: {})
-        get_fleet_wings_raw(fleet_id: fleet_id, headers: headers, params: params).json
+        parse_response(get_fleet_wings_raw(fleet_id: fleet_id, headers: headers, params: params))
       end
       alias get_fleets_fleet_id_wings get_fleet_wings
 
@@ -450,7 +450,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/post_fleets_fleet_id_members
       def post_fleet_members(fleet_id:, invitation:, headers: {}, params: {})
-        post_fleet_members_raw(fleet_id: fleet_id, invitation: invitation, headers: headers, params: params).json
+        parse_response(post_fleet_members_raw(fleet_id: fleet_id, invitation: invitation, headers: headers, params: params))
       end
       alias post_fleets_fleet_id_members post_fleet_members
 
@@ -510,7 +510,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/post_fleets_fleet_id_wings_wing_id_squads
       def post_fleet_wing_squads(fleet_id:, wing_id:, headers: {}, params: {})
-        post_fleet_wing_squads_raw(fleet_id: fleet_id, wing_id: wing_id, headers: headers, params: params).json
+        parse_response(post_fleet_wing_squads_raw(fleet_id: fleet_id, wing_id: wing_id, headers: headers, params: params))
       end
       alias post_fleets_fleet_id_wings_wing_id_squads post_fleet_wing_squads
 
@@ -568,7 +568,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/post_fleets_fleet_id_wings
       def post_fleet_wings(fleet_id:, headers: {}, params: {})
-        post_fleet_wings_raw(fleet_id: fleet_id, headers: headers, params: params).json
+        parse_response(post_fleet_wings_raw(fleet_id: fleet_id, headers: headers, params: params))
       end
       alias post_fleets_fleet_id_wings post_fleet_wings
 
@@ -626,7 +626,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/put_fleets_fleet_id
       def put_fleet(fleet_id:, new_settings:, headers: {}, params: {})
-        put_fleet_raw(fleet_id: fleet_id, new_settings: new_settings, headers: headers, params: params).json
+        parse_response(put_fleet_raw(fleet_id: fleet_id, new_settings: new_settings, headers: headers, params: params))
       end
       alias put_fleets_fleet_id put_fleet
 
@@ -687,7 +687,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/put_fleets_fleet_id_members_member_id
       def put_fleet_member(fleet_id:, member_id:, movement:, headers: {}, params: {})
-        put_fleet_member_raw(fleet_id: fleet_id, member_id: member_id, movement: movement, headers: headers, params: params).json
+        parse_response(put_fleet_member_raw(fleet_id: fleet_id, member_id: member_id, movement: movement, headers: headers, params: params))
       end
       alias put_fleets_fleet_id_members_member_id put_fleet_member
 
@@ -749,7 +749,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/put_fleets_fleet_id_squads_squad_id
       def put_fleet_squad(fleet_id:, squad_id:, naming:, headers: {}, params: {})
-        put_fleet_squad_raw(fleet_id: fleet_id, squad_id: squad_id, naming: naming, headers: headers, params: params).json
+        parse_response(put_fleet_squad_raw(fleet_id: fleet_id, squad_id: squad_id, naming: naming, headers: headers, params: params))
       end
       alias put_fleets_fleet_id_squads_squad_id put_fleet_squad
 
@@ -810,7 +810,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Fleets/put_fleets_fleet_id_wings_wing_id
       def put_fleet_wing(fleet_id:, wing_id:, naming:, headers: {}, params: {})
-        put_fleet_wing_raw(fleet_id: fleet_id, wing_id: wing_id, naming: naming, headers: headers, params: params).json
+        parse_response(put_fleet_wing_raw(fleet_id: fleet_id, wing_id: wing_id, naming: naming, headers: headers, params: params))
       end
       alias put_fleets_fleet_id_wings_wing_id put_fleet_wing
 

--- a/lib/esi/client/incursions.rb
+++ b/lib/esi/client/incursions.rb
@@ -23,7 +23,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Incursions/get_incursions
       def get_incursions(headers: {}, params: {})
-        get_incursions_raw(headers: headers, params: params).json
+        parse_response(get_incursions_raw(headers: headers, params: params))
       end
 
       # Return a list of current incursions.
@@ -45,7 +45,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Incursions/get_incursions
       def get_incursions_raw(headers: {}, params: {})
-        get("/incursions/", headers: headers, params: params)
+        get('/incursions/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/industry.rb
+++ b/lib/esi/client/industry.rb
@@ -31,7 +31,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Industry/get_characters_character_id_industry_jobs
       def get_character_industry_jobs(character_id:, include_completed: nil, headers: {}, params: {})
-        get_character_industry_jobs_raw(character_id: character_id, include_completed: include_completed, headers: headers, params: params).json
+        parse_response(get_character_industry_jobs_raw(character_id: character_id, include_completed: include_completed, headers: headers, params: params))
       end
       alias get_characters_character_id_industry_jobs get_character_industry_jobs
 
@@ -62,7 +62,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Industry/get_characters_character_id_industry_jobs
       def get_character_industry_jobs_raw(character_id:, include_completed: nil, headers: {}, params: {})
-        params.merge!("include_completed" => include_completed)
+        params.merge!('include_completed' => include_completed)
         get("/characters/#{character_id}/industry/jobs/", headers: headers, params: params)
       end
 
@@ -152,7 +152,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Industry/get_corporations_corporation_id_industry_jobs
       def get_corporation_industry_jobs(corporation_id:, include_completed: nil, headers: {}, params: {})
-        params.merge!("include_completed" => include_completed)
+        params.merge!('include_completed' => include_completed)
         concat_responses(get_corporation_industry_jobs_raw(corporation_id: corporation_id, include_completed: include_completed, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_industry_jobs get_corporation_industry_jobs
@@ -184,7 +184,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Industry/get_corporations_corporation_id_industry_jobs
       def get_corporation_industry_jobs_raw(corporation_id:, include_completed: nil, headers: {}, params: {})
-        params.merge!("include_completed" => include_completed)
+        params.merge!('include_completed' => include_completed)
         get("/corporations/#{corporation_id}/industry/jobs/", headers: headers, params: params)
       end
 
@@ -386,7 +386,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Industry/get_industry_facilities
       def get_industry_facilities(headers: {}, params: {})
-        get_industry_facilities_raw(headers: headers, params: params).json
+        parse_response(get_industry_facilities_raw(headers: headers, params: params))
       end
 
       # Return a list of industry facilities.
@@ -408,7 +408,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Industry/get_industry_facilities
       def get_industry_facilities_raw(headers: {}, params: {})
-        get("/industry/facilities/", headers: headers, params: params)
+        get('/industry/facilities/', headers: headers, params: params)
       end
 
       # Return cost indices for solar systems.
@@ -430,7 +430,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Industry/get_industry_systems
       def get_industry_systems(headers: {}, params: {})
-        get_industry_systems_raw(headers: headers, params: params).json
+        parse_response(get_industry_systems_raw(headers: headers, params: params))
       end
 
       # Return cost indices for solar systems.
@@ -452,7 +452,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Industry/get_industry_systems
       def get_industry_systems_raw(headers: {}, params: {})
-        get("/industry/systems/", headers: headers, params: params)
+        get('/industry/systems/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/insurance.rb
+++ b/lib/esi/client/insurance.rb
@@ -23,7 +23,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Insurance/get_insurance_prices
       def get_insurance_prices(headers: {}, params: {})
-        get_insurance_prices_raw(headers: headers, params: params).json
+        parse_response(get_insurance_prices_raw(headers: headers, params: params))
       end
 
       # Return available insurance levels for all ship types.
@@ -45,7 +45,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Insurance/get_insurance_prices
       def get_insurance_prices_raw(headers: {}, params: {})
-        get("/insurance/prices/", headers: headers, params: params)
+        get('/insurance/prices/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/killmails.rb
+++ b/lib/esi/client/killmails.rb
@@ -144,7 +144,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Killmails/get_killmails_killmail_id_killmail_hash
       def get_killmail_killmail_hash(killmail_hash:, killmail_id:, headers: {}, params: {})
-        get_killmail_killmail_hash_raw(killmail_hash: killmail_hash, killmail_id: killmail_id, headers: headers, params: params).json
+        parse_response(get_killmail_killmail_hash_raw(killmail_hash: killmail_hash, killmail_id: killmail_id, headers: headers, params: params))
       end
       alias get_killmail get_killmail_killmail_hash
       alias get_killmails_killmail_id_killmail_hash get_killmail_killmail_hash

--- a/lib/esi/client/location.rb
+++ b/lib/esi/client/location.rb
@@ -31,7 +31,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Location/get_characters_character_id_location
       def get_character_location(character_id:, headers: {}, params: {})
-        get_character_location_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_location_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_location get_character_location
 
@@ -91,7 +91,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Location/get_characters_character_id_online
       def get_character_online(character_id:, headers: {}, params: {})
-        get_character_online_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_online_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_online get_character_online
 
@@ -151,7 +151,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Location/get_characters_character_id_ship
       def get_character_ship(character_id:, headers: {}, params: {})
-        get_character_ship_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_ship_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_ship get_character_ship
 

--- a/lib/esi/client/loyalty.rb
+++ b/lib/esi/client/loyalty.rb
@@ -30,7 +30,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Loyalty/get_characters_character_id_loyalty_points
       def get_character_loyalty_points(character_id:, headers: {}, params: {})
-        get_character_loyalty_points_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_loyalty_points_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_loyalty_points get_character_loyalty_points
 
@@ -82,7 +82,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Loyalty/get_loyalty_stores_corporation_id_offers
       def get_loyalty_stores_corporation_offers(corporation_id:, headers: {}, params: {})
-        get_loyalty_stores_corporation_offers_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_loyalty_stores_corporation_offers_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_loyalty_stores_corporation_id_offers get_loyalty_stores_corporation_offers
 

--- a/lib/esi/client/mail.rb
+++ b/lib/esi/client/mail.rb
@@ -29,7 +29,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Mail/delete_characters_character_id_mail_mail_id
       def delete_character_mail(character_id:, mail_id:, headers: {}, params: {})
-        delete_character_mail_raw(character_id: character_id, mail_id: mail_id, headers: headers, params: params).json
+        parse_response(delete_character_mail_raw(character_id: character_id, mail_id: mail_id, headers: headers, params: params))
       end
       alias delete_characters_character_id_mail_mail_id delete_character_mail
 
@@ -87,7 +87,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Mail/delete_characters_character_id_mail_labels_label_id
       def delete_character_mail_label(character_id:, label_id:, headers: {}, params: {})
-        delete_character_mail_label_raw(character_id: character_id, label_id: label_id, headers: headers, params: params).json
+        parse_response(delete_character_mail_label_raw(character_id: character_id, label_id: label_id, headers: headers, params: params))
       end
       alias delete_characters_character_id_mail_labels_label_id delete_character_mail_label
 
@@ -148,7 +148,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Mail/get_characters_character_id_mail_mail_id
       def get_character_mail(character_id:, mail_id:, headers: {}, params: {})
-        get_character_mail_raw(character_id: character_id, mail_id: mail_id, headers: headers, params: params).json
+        parse_response(get_character_mail_raw(character_id: character_id, mail_id: mail_id, headers: headers, params: params))
       end
       alias get_characters_character_id_mail_mail_id get_character_mail
 
@@ -208,7 +208,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Mail/get_characters_character_id_mail_labels
       def get_character_mail_labels(character_id:, headers: {}, params: {})
-        get_character_mail_labels_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_mail_labels_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_mail_labels get_character_mail_labels
 
@@ -266,7 +266,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Mail/get_characters_character_id_mail_lists
       def get_character_mail_lists(character_id:, headers: {}, params: {})
-        get_character_mail_lists_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_mail_lists_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_mail_lists get_character_mail_lists
 
@@ -325,7 +325,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Mail/post_characters_character_id_mail
       def post_character_mail(character_id:, mail:, headers: {}, params: {})
-        post_character_mail_raw(character_id: character_id, mail: mail, headers: headers, params: params).json
+        parse_response(post_character_mail_raw(character_id: character_id, mail: mail, headers: headers, params: params))
       end
       alias post_characters_character_id_mail post_character_mail
 
@@ -383,7 +383,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Mail/post_characters_character_id_mail_labels
       def post_character_mail_labels(character_id:, label:, headers: {}, params: {})
-        post_character_mail_labels_raw(character_id: character_id, label: label, headers: headers, params: params).json
+        parse_response(post_character_mail_labels_raw(character_id: character_id, label: label, headers: headers, params: params))
       end
       alias post_characters_character_id_mail_labels post_character_mail_labels
 
@@ -441,7 +441,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Mail/put_characters_character_id_mail_mail_id
       def put_character_mail(character_id:, mail_id:, contents:, headers: {}, params: {})
-        put_character_mail_raw(character_id: character_id, mail_id: mail_id, contents: contents, headers: headers, params: params).json
+        parse_response(put_character_mail_raw(character_id: character_id, mail_id: mail_id, contents: contents, headers: headers, params: params))
       end
       alias put_characters_character_id_mail_mail_id put_character_mail
 

--- a/lib/esi/client/market.rb
+++ b/lib/esi/client/market.rb
@@ -29,7 +29,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Market/get_characters_character_id_orders
       def get_character_orders(character_id:, headers: {}, params: {})
-        get_character_orders_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_orders_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_orders get_character_orders
 
@@ -251,7 +251,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_groups
       def get_market_groups(headers: {}, params: {})
-        get_market_groups_raw(headers: headers, params: params).json
+        parse_response(get_market_groups_raw(headers: headers, params: params))
       end
       alias get_markets_groups get_market_groups
 
@@ -272,7 +272,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_groups
       def get_market_groups_raw(headers: {}, params: {})
-        get("/markets/groups/", headers: headers, params: params)
+        get('/markets/groups/', headers: headers, params: params)
       end
 
       # Get information on an item group.
@@ -294,7 +294,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_groups_market_group_id
       def get_market_groups_market_group(market_group_id:, headers: {}, params: {})
-        get_market_groups_market_group_raw(market_group_id: market_group_id, headers: headers, params: params).json
+        parse_response(get_market_groups_market_group_raw(market_group_id: market_group_id, headers: headers, params: params))
       end
       alias get_markets_groups_market_group_id get_market_groups_market_group
 
@@ -339,7 +339,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_prices
       def get_market_prices(headers: {}, params: {})
-        get_market_prices_raw(headers: headers, params: params).json
+        parse_response(get_market_prices_raw(headers: headers, params: params))
       end
       alias get_markets_prices get_market_prices
 
@@ -362,7 +362,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_prices
       def get_market_prices_raw(headers: {}, params: {})
-        get("/markets/prices/", headers: headers, params: params)
+        get('/markets/prices/', headers: headers, params: params)
       end
 
       # Return a list of historical market statistics for the specified type in a region.
@@ -387,7 +387,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_region_id_history
       def get_markets_region_history(region_id:, type_id:, headers: {}, params: {})
-        get_markets_region_history_raw(region_id: region_id, type_id: type_id, headers: headers, params: params).json
+        parse_response(get_markets_region_history_raw(region_id: region_id, type_id: type_id, headers: headers, params: params))
       end
       alias get_markets_region_id_history get_markets_region_history
 
@@ -413,7 +413,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_region_id_history
       def get_markets_region_history_raw(region_id:, type_id:, headers: {}, params: {})
-        params.merge!("type_id" => type_id)
+        params.merge!('type_id' => type_id)
         get("/markets/#{region_id}/history/", headers: headers, params: params)
       end
 
@@ -440,8 +440,8 @@ module ESI
       # @raise [ESI::Errors::GatewayTimeoutError] Gateway timeout
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_region_id_orders
-      def get_markets_region_orders(region_id:, order_type: "all", type_id: nil, headers: {}, params: {})
-        params.merge!("order_type" => order_type, "type_id" => type_id)
+      def get_markets_region_orders(region_id:, order_type: 'all', type_id: nil, headers: {}, params: {})
+        params.merge!('order_type' => order_type, 'type_id' => type_id)
         concat_responses(get_markets_region_orders_raw(region_id: region_id, order_type: order_type, type_id: type_id, headers: headers, params: params))
       end
       alias get_markets_region_id_orders get_markets_region_orders
@@ -469,8 +469,8 @@ module ESI
       # @raise [ESI::Errors::GatewayTimeoutError] Gateway timeout
       #
       # @see https://esi.evetech.net/ui/#/Market/get_markets_region_id_orders
-      def get_markets_region_orders_raw(region_id:, order_type: "all", type_id: nil, headers: {}, params: {})
-        params.merge!("order_type" => order_type, "type_id" => type_id)
+      def get_markets_region_orders_raw(region_id:, order_type: 'all', type_id: nil, headers: {}, params: {})
+        params.merge!('order_type' => order_type, 'type_id' => type_id)
         get("/markets/#{region_id}/orders/", headers: headers, params: params)
       end
 

--- a/lib/esi/client/opportunities.rb
+++ b/lib/esi/client/opportunities.rb
@@ -30,7 +30,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Opportunities/get_characters_character_id_opportunities
       def get_character_opportunities(character_id:, headers: {}, params: {})
-        get_character_opportunities_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_opportunities_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_opportunities get_character_opportunities
 
@@ -81,7 +81,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Opportunities/get_opportunities_groups_group_id
       def get_opportunities_group(group_id:, headers: {}, params: {})
-        get_opportunities_group_raw(group_id: group_id, headers: headers, params: params).json
+        parse_response(get_opportunities_group_raw(group_id: group_id, headers: headers, params: params))
       end
       alias get_opportunities_groups_group_id get_opportunities_group
 
@@ -124,7 +124,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Opportunities/get_opportunities_tasks_task_id
       def get_opportunities_task(task_id:, headers: {}, params: {})
-        get_opportunities_task_raw(task_id: task_id, headers: headers, params: params).json
+        parse_response(get_opportunities_task_raw(task_id: task_id, headers: headers, params: params))
       end
       alias get_opportunities_tasks_task_id get_opportunities_task
 
@@ -166,7 +166,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Opportunities/get_opportunities_groups
       def get_opportunity_groups(headers: {}, params: {})
-        get_opportunity_groups_raw(headers: headers, params: params).json
+        parse_response(get_opportunity_groups_raw(headers: headers, params: params))
       end
       alias get_opportunities_groups get_opportunity_groups
 
@@ -187,7 +187,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Opportunities/get_opportunities_groups
       def get_opportunity_groups_raw(headers: {}, params: {})
-        get("/opportunities/groups/", headers: headers, params: params)
+        get('/opportunities/groups/', headers: headers, params: params)
       end
 
       # Return a list of opportunities tasks.
@@ -207,7 +207,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Opportunities/get_opportunities_tasks
       def get_opportunity_tasks(headers: {}, params: {})
-        get_opportunity_tasks_raw(headers: headers, params: params).json
+        parse_response(get_opportunity_tasks_raw(headers: headers, params: params))
       end
       alias get_opportunities_tasks get_opportunity_tasks
 
@@ -228,7 +228,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Opportunities/get_opportunities_tasks
       def get_opportunity_tasks_raw(headers: {}, params: {})
-        get("/opportunities/tasks/", headers: headers, params: params)
+        get('/opportunities/tasks/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/planetary_interaction.rb
+++ b/lib/esi/client/planetary_interaction.rb
@@ -29,7 +29,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Planetary Interaction/get_characters_character_id_planets_planet_id
       def get_character_planet(character_id:, planet_id:, headers: {}, params: {})
-        get_character_planet_raw(character_id: character_id, planet_id: planet_id, headers: headers, params: params).json
+        parse_response(get_character_planet_raw(character_id: character_id, planet_id: planet_id, headers: headers, params: params))
       end
       alias get_characters_character_id_planets_planet_id get_character_planet
 
@@ -87,7 +87,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Planetary Interaction/get_characters_character_id_planets
       def get_character_planets(character_id:, headers: {}, params: {})
-        get_character_planets_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_planets_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_planets get_character_planets
 
@@ -200,7 +200,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Planetary Interaction/get_universe_schematics_schematic_id
       def get_universe_schematic(schematic_id:, headers: {}, params: {})
-        get_universe_schematic_raw(schematic_id: schematic_id, headers: headers, params: params).json
+        parse_response(get_universe_schematic_raw(schematic_id: schematic_id, headers: headers, params: params))
       end
       alias get_universe_schematics_schematic_id get_universe_schematic
 

--- a/lib/esi/client/routes.rb
+++ b/lib/esi/client/routes.rb
@@ -28,8 +28,8 @@ module ESI
       # @raise [ESI::Errors::GatewayTimeoutError] Gateway timeout
       #
       # @see https://esi.evetech.net/ui/#/Routes/get_route_origin_destination
-      def get_route_origin_destination(destination:, origin:, avoid: nil, connections: nil, flag: "shortest", headers: {}, params: {})
-        get_route_origin_destination_raw(destination: destination, origin: origin, avoid: avoid, connections: connections, flag: flag, headers: headers, params: params).json
+      def get_route_origin_destination(destination:, origin:, avoid: nil, connections: nil, flag: 'shortest', headers: {}, params: {})
+        parse_response(get_route_origin_destination_raw(destination: destination, origin: origin, avoid: avoid, connections: connections, flag: flag, headers: headers, params: params))
       end
 
       # Get the systems between origin and destination.
@@ -56,8 +56,8 @@ module ESI
       # @raise [ESI::Errors::GatewayTimeoutError] Gateway timeout
       #
       # @see https://esi.evetech.net/ui/#/Routes/get_route_origin_destination
-      def get_route_origin_destination_raw(destination:, origin:, avoid: nil, connections: nil, flag: "shortest", headers: {}, params: {})
-        params.merge!("avoid" => avoid, "connections" => connections, "flag" => flag)
+      def get_route_origin_destination_raw(destination:, origin:, avoid: nil, connections: nil, flag: 'shortest', headers: {}, params: {})
+        params.merge!('avoid' => avoid, 'connections' => connections, 'flag' => flag)
         get("/route/#{origin}/#{destination}/", headers: headers, params: params)
       end
     end

--- a/lib/esi/client/search.rb
+++ b/lib/esi/client/search.rb
@@ -33,7 +33,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Search/get_characters_character_id_search
       def get_character_search(character_id:, categories:, search:, strict: nil, headers: {}, params: {})
-        get_character_search_raw(character_id: character_id, categories: categories, search: search, strict: strict, headers: headers, params: params).json
+        parse_response(get_character_search_raw(character_id: character_id, categories: categories, search: search, strict: strict, headers: headers, params: params))
       end
       alias get_characters_character_id_search get_character_search
 
@@ -66,7 +66,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Search/get_characters_character_id_search
       def get_character_search_raw(character_id:, categories:, search:, strict: nil, headers: {}, params: {})
-        params.merge!("categories" => categories, "search" => search, "strict" => strict)
+        params.merge!('categories' => categories, 'search' => search, 'strict' => strict)
         get("/characters/#{character_id}/search/", headers: headers, params: params)
       end
 
@@ -92,7 +92,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Search/get_search
       def get_search(categories:, search:, strict: nil, headers: {}, params: {})
-        get_search_raw(categories: categories, search: search, strict: strict, headers: headers, params: params).json
+        parse_response(get_search_raw(categories: categories, search: search, strict: strict, headers: headers, params: params))
       end
 
       # Search for entities that match a given sub-string.
@@ -117,8 +117,8 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Search/get_search
       def get_search_raw(categories:, search:, strict: nil, headers: {}, params: {})
-        params.merge!("categories" => categories, "search" => search, "strict" => strict)
-        get("/search/", headers: headers, params: params)
+        params.merge!('categories' => categories, 'search' => search, 'strict' => strict)
+        get('/search/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/skills.rb
+++ b/lib/esi/client/skills.rb
@@ -30,7 +30,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Skills/get_characters_character_id_attributes
       def get_character_attributes(character_id:, headers: {}, params: {})
-        get_character_attributes_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_attributes_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_attributes get_character_attributes
 
@@ -89,7 +89,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Skills/get_characters_character_id_skillqueue
       def get_character_skillqueue(character_id:, headers: {}, params: {})
-        get_character_skillqueue_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_skillqueue_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_skillqueue get_character_skillqueue
 
@@ -147,7 +147,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Skills/get_characters_character_id_skills
       def get_character_skills(character_id:, headers: {}, params: {})
-        get_character_skills_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_skills_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_skills get_character_skills
 

--- a/lib/esi/client/sovereignty.rb
+++ b/lib/esi/client/sovereignty.rb
@@ -23,7 +23,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Sovereignty/get_sovereignty_campaigns
       def get_sovereignty_campaigns(headers: {}, params: {})
-        get_sovereignty_campaigns_raw(headers: headers, params: params).json
+        parse_response(get_sovereignty_campaigns_raw(headers: headers, params: params))
       end
 
       # Shows sovereignty data for campaigns.
@@ -45,7 +45,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Sovereignty/get_sovereignty_campaigns
       def get_sovereignty_campaigns_raw(headers: {}, params: {})
-        get("/sovereignty/campaigns/", headers: headers, params: params)
+        get('/sovereignty/campaigns/', headers: headers, params: params)
       end
 
       # Shows sovereignty information for solar systems.
@@ -67,7 +67,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Sovereignty/get_sovereignty_map
       def get_sovereignty_map(headers: {}, params: {})
-        get_sovereignty_map_raw(headers: headers, params: params).json
+        parse_response(get_sovereignty_map_raw(headers: headers, params: params))
       end
 
       # Shows sovereignty information for solar systems.
@@ -89,7 +89,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Sovereignty/get_sovereignty_map
       def get_sovereignty_map_raw(headers: {}, params: {})
-        get("/sovereignty/map/", headers: headers, params: params)
+        get('/sovereignty/map/', headers: headers, params: params)
       end
 
       # Shows sovereignty data for structures.
@@ -111,7 +111,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Sovereignty/get_sovereignty_structures
       def get_sovereignty_structures(headers: {}, params: {})
-        get_sovereignty_structures_raw(headers: headers, params: params).json
+        parse_response(get_sovereignty_structures_raw(headers: headers, params: params))
       end
 
       # Shows sovereignty data for structures.
@@ -133,7 +133,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Sovereignty/get_sovereignty_structures
       def get_sovereignty_structures_raw(headers: {}, params: {})
-        get("/sovereignty/structures/", headers: headers, params: params)
+        get('/sovereignty/structures/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/status.rb
+++ b/lib/esi/client/status.rb
@@ -24,7 +24,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Status/get_status
       def get_status(headers: {}, params: {})
-        get_status_raw(headers: headers, params: params).json
+        parse_response(get_status_raw(headers: headers, params: params))
       end
 
       # EVE Server status.
@@ -47,7 +47,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Status/get_status
       def get_status_raw(headers: {}, params: {})
-        get("/status/", headers: headers, params: params)
+        get('/status/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/client/universe.rb
+++ b/lib/esi/client/universe.rb
@@ -20,7 +20,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_ancestries
       def get_universe_ancestries(headers: {}, params: {})
-        get_universe_ancestries_raw(headers: headers, params: params).json
+        parse_response(get_universe_ancestries_raw(headers: headers, params: params))
       end
 
       # Get all character ancestries.
@@ -39,7 +39,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_ancestries
       def get_universe_ancestries_raw(headers: {}, params: {})
-        get("/universe/ancestries/", headers: headers, params: params)
+        get('/universe/ancestries/', headers: headers, params: params)
       end
 
       # Get information on an asteroid belt.
@@ -60,7 +60,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_asteroid_belts_asteroid_belt_id
       def get_universe_asteroid_belt(asteroid_belt_id:, headers: {}, params: {})
-        get_universe_asteroid_belt_raw(asteroid_belt_id: asteroid_belt_id, headers: headers, params: params).json
+        parse_response(get_universe_asteroid_belt_raw(asteroid_belt_id: asteroid_belt_id, headers: headers, params: params))
       end
       alias get_universe_asteroid_belts_asteroid_belt_id get_universe_asteroid_belt
 
@@ -101,7 +101,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_bloodlines
       def get_universe_bloodlines(headers: {}, params: {})
-        get_universe_bloodlines_raw(headers: headers, params: params).json
+        parse_response(get_universe_bloodlines_raw(headers: headers, params: params))
       end
 
       # Get a list of bloodlines.
@@ -120,7 +120,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_bloodlines
       def get_universe_bloodlines_raw(headers: {}, params: {})
-        get("/universe/bloodlines/", headers: headers, params: params)
+        get('/universe/bloodlines/', headers: headers, params: params)
       end
 
       # Get a list of item categories.
@@ -139,7 +139,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_categories
       def get_universe_categories(headers: {}, params: {})
-        get_universe_categories_raw(headers: headers, params: params).json
+        parse_response(get_universe_categories_raw(headers: headers, params: params))
       end
 
       # Get a list of item categories.
@@ -158,7 +158,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_categories
       def get_universe_categories_raw(headers: {}, params: {})
-        get("/universe/categories/", headers: headers, params: params)
+        get('/universe/categories/', headers: headers, params: params)
       end
 
       # Get information of an item category.
@@ -179,7 +179,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_categories_category_id
       def get_universe_categories_category(category_id:, headers: {}, params: {})
-        get_universe_categories_category_raw(category_id: category_id, headers: headers, params: params).json
+        parse_response(get_universe_categories_category_raw(category_id: category_id, headers: headers, params: params))
       end
       alias get_universe_categories_category_id get_universe_categories_category
 
@@ -222,7 +222,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_constellations_constellation_id
       def get_universe_constellation(constellation_id:, headers: {}, params: {})
-        get_universe_constellation_raw(constellation_id: constellation_id, headers: headers, params: params).json
+        parse_response(get_universe_constellation_raw(constellation_id: constellation_id, headers: headers, params: params))
       end
       alias get_universe_constellations_constellation_id get_universe_constellation
 
@@ -263,7 +263,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_constellations
       def get_universe_constellations(headers: {}, params: {})
-        get_universe_constellations_raw(headers: headers, params: params).json
+        parse_response(get_universe_constellations_raw(headers: headers, params: params))
       end
 
       # Get a list of constellations.
@@ -282,7 +282,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_constellations
       def get_universe_constellations_raw(headers: {}, params: {})
-        get("/universe/constellations/", headers: headers, params: params)
+        get('/universe/constellations/', headers: headers, params: params)
       end
 
       # Get a list of factions.
@@ -301,7 +301,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_factions
       def get_universe_factions(headers: {}, params: {})
-        get_universe_factions_raw(headers: headers, params: params).json
+        parse_response(get_universe_factions_raw(headers: headers, params: params))
       end
 
       # Get a list of factions.
@@ -320,7 +320,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_factions
       def get_universe_factions_raw(headers: {}, params: {})
-        get("/universe/factions/", headers: headers, params: params)
+        get('/universe/factions/', headers: headers, params: params)
       end
 
       # Get information on a graphic.
@@ -342,7 +342,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_graphics_graphic_id
       def get_universe_graphic(graphic_id:, headers: {}, params: {})
-        get_universe_graphic_raw(graphic_id: graphic_id, headers: headers, params: params).json
+        parse_response(get_universe_graphic_raw(graphic_id: graphic_id, headers: headers, params: params))
       end
       alias get_universe_graphics_graphic_id get_universe_graphic
 
@@ -384,7 +384,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_graphics
       def get_universe_graphics(headers: {}, params: {})
-        get_universe_graphics_raw(headers: headers, params: params).json
+        parse_response(get_universe_graphics_raw(headers: headers, params: params))
       end
 
       # Get a list of graphics.
@@ -403,7 +403,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_graphics
       def get_universe_graphics_raw(headers: {}, params: {})
-        get("/universe/graphics/", headers: headers, params: params)
+        get('/universe/graphics/', headers: headers, params: params)
       end
 
       # Get information on an item group.
@@ -425,7 +425,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_groups_group_id
       def get_universe_group(group_id:, headers: {}, params: {})
-        get_universe_group_raw(group_id: group_id, headers: headers, params: params).json
+        parse_response(get_universe_group_raw(group_id: group_id, headers: headers, params: params))
       end
       alias get_universe_groups_group_id get_universe_group
 
@@ -486,7 +486,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_groups
       def get_universe_groups_raw(headers: {}, params: {})
-        get("/universe/groups/", headers: headers, params: params)
+        get('/universe/groups/', headers: headers, params: params)
       end
 
       # Get information on a moon.
@@ -507,7 +507,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_moons_moon_id
       def get_universe_moon(moon_id:, headers: {}, params: {})
-        get_universe_moon_raw(moon_id: moon_id, headers: headers, params: params).json
+        parse_response(get_universe_moon_raw(moon_id: moon_id, headers: headers, params: params))
       end
       alias get_universe_moons_moon_id get_universe_moon
 
@@ -550,7 +550,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_planets_planet_id
       def get_universe_planet(planet_id:, headers: {}, params: {})
-        get_universe_planet_raw(planet_id: planet_id, headers: headers, params: params).json
+        parse_response(get_universe_planet_raw(planet_id: planet_id, headers: headers, params: params))
       end
       alias get_universe_planets_planet_id get_universe_planet
 
@@ -592,7 +592,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_races
       def get_universe_races(headers: {}, params: {})
-        get_universe_races_raw(headers: headers, params: params).json
+        parse_response(get_universe_races_raw(headers: headers, params: params))
       end
 
       # Get a list of character races.
@@ -612,7 +612,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_races
       def get_universe_races_raw(headers: {}, params: {})
-        get("/universe/races/", headers: headers, params: params)
+        get('/universe/races/', headers: headers, params: params)
       end
 
       # Get information on a region.
@@ -633,7 +633,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_regions_region_id
       def get_universe_region(region_id:, headers: {}, params: {})
-        get_universe_region_raw(region_id: region_id, headers: headers, params: params).json
+        parse_response(get_universe_region_raw(region_id: region_id, headers: headers, params: params))
       end
       alias get_universe_regions_region_id get_universe_region
 
@@ -674,7 +674,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_regions
       def get_universe_regions(headers: {}, params: {})
-        get_universe_regions_raw(headers: headers, params: params).json
+        parse_response(get_universe_regions_raw(headers: headers, params: params))
       end
 
       # Get a list of regions.
@@ -693,7 +693,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_regions
       def get_universe_regions_raw(headers: {}, params: {})
-        get("/universe/regions/", headers: headers, params: params)
+        get('/universe/regions/', headers: headers, params: params)
       end
 
       # Get information on a star.
@@ -713,7 +713,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_stars_star_id
       def get_universe_star(star_id:, headers: {}, params: {})
-        get_universe_star_raw(star_id: star_id, headers: headers, params: params).json
+        parse_response(get_universe_star_raw(star_id: star_id, headers: headers, params: params))
       end
       alias get_universe_stars_star_id get_universe_star
 
@@ -755,7 +755,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_stargates_stargate_id
       def get_universe_stargate(stargate_id:, headers: {}, params: {})
-        get_universe_stargate_raw(stargate_id: stargate_id, headers: headers, params: params).json
+        parse_response(get_universe_stargate_raw(stargate_id: stargate_id, headers: headers, params: params))
       end
       alias get_universe_stargates_stargate_id get_universe_stargate
 
@@ -798,7 +798,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_stations_station_id
       def get_universe_station(station_id:, headers: {}, params: {})
-        get_universe_station_raw(station_id: station_id, headers: headers, params: params).json
+        parse_response(get_universe_station_raw(station_id: station_id, headers: headers, params: params))
       end
       alias get_universe_stations_station_id get_universe_station
 
@@ -848,7 +848,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_structures_structure_id
       def get_universe_structure(structure_id:, headers: {}, params: {})
-        get_universe_structure_raw(structure_id: structure_id, headers: headers, params: params).json
+        parse_response(get_universe_structure_raw(structure_id: structure_id, headers: headers, params: params))
       end
       alias get_universe_structures_structure_id get_universe_structure
 
@@ -900,7 +900,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_structures
       def get_universe_structures(filter: nil, headers: {}, params: {})
-        get_universe_structures_raw(filter: filter, headers: headers, params: params).json
+        parse_response(get_universe_structures_raw(filter: filter, headers: headers, params: params))
       end
 
       # List all public structures.
@@ -923,8 +923,8 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_structures
       def get_universe_structures_raw(filter: nil, headers: {}, params: {})
-        params.merge!("filter" => filter)
-        get("/universe/structures/", headers: headers, params: params)
+        params.merge!('filter' => filter)
+        get('/universe/structures/', headers: headers, params: params)
       end
 
       # Get information on a solar system.
@@ -945,7 +945,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_systems_system_id
       def get_universe_system(system_id:, headers: {}, params: {})
-        get_universe_system_raw(system_id: system_id, headers: headers, params: params).json
+        parse_response(get_universe_system_raw(system_id: system_id, headers: headers, params: params))
       end
       alias get_universe_systems_system_id get_universe_system
 
@@ -988,7 +988,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_system_jumps
       def get_universe_system_jumps(headers: {}, params: {})
-        get_universe_system_jumps_raw(headers: headers, params: params).json
+        parse_response(get_universe_system_jumps_raw(headers: headers, params: params))
       end
 
       # Get the number of jumps in solar systems within the last hour ending at the timestamp of the Last-Modified header, excluding wormhole space. Only systems with jumps will be listed.
@@ -1009,7 +1009,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_system_jumps
       def get_universe_system_jumps_raw(headers: {}, params: {})
-        get("/universe/system_jumps/", headers: headers, params: params)
+        get('/universe/system_jumps/', headers: headers, params: params)
       end
 
       # Get the number of ship, pod and NPC kills per solar system within the last hour ending at the timestamp of the Last-Modified header, excluding wormhole space. Only systems with kills will be listed.
@@ -1029,7 +1029,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_system_kills
       def get_universe_system_kills(headers: {}, params: {})
-        get_universe_system_kills_raw(headers: headers, params: params).json
+        parse_response(get_universe_system_kills_raw(headers: headers, params: params))
       end
 
       # Get the number of ship, pod and NPC kills per solar system within the last hour ending at the timestamp of the Last-Modified header, excluding wormhole space. Only systems with kills will be listed.
@@ -1049,7 +1049,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_system_kills
       def get_universe_system_kills_raw(headers: {}, params: {})
-        get("/universe/system_kills/", headers: headers, params: params)
+        get('/universe/system_kills/', headers: headers, params: params)
       end
 
       # Get a list of solar systems.
@@ -1069,7 +1069,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_systems
       def get_universe_systems(headers: {}, params: {})
-        get_universe_systems_raw(headers: headers, params: params).json
+        parse_response(get_universe_systems_raw(headers: headers, params: params))
       end
 
       # Get a list of solar systems.
@@ -1089,7 +1089,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_systems
       def get_universe_systems_raw(headers: {}, params: {})
-        get("/universe/systems/", headers: headers, params: params)
+        get('/universe/systems/', headers: headers, params: params)
       end
 
       # Get information on a type.
@@ -1110,7 +1110,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_types_type_id
       def get_universe_type(type_id:, headers: {}, params: {})
-        get_universe_type_raw(type_id: type_id, headers: headers, params: params).json
+        parse_response(get_universe_type_raw(type_id: type_id, headers: headers, params: params))
       end
       alias get_universe_types_type_id get_universe_type
 
@@ -1170,7 +1170,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/get_universe_types
       def get_universe_types_raw(headers: {}, params: {})
-        get("/universe/types/", headers: headers, params: params)
+        get('/universe/types/', headers: headers, params: params)
       end
 
       # Resolve a set of names to IDs in the following categories: agents, alliances, characters, constellations, corporations factions, inventory_types, regions, stations, and systems. Only exact matches will be returned. All names searched for are cached for 12 hours.
@@ -1191,7 +1191,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/post_universe_ids
       def post_universe_ids(names:, headers: {}, params: {})
-        post_universe_ids_raw(names: names, headers: headers, params: params).json
+        parse_response(post_universe_ids_raw(names: names, headers: headers, params: params))
       end
 
       # Resolve a set of names to IDs in the following categories: agents, alliances, characters, constellations, corporations factions, inventory_types, regions, stations, and systems. Only exact matches will be returned. All names searched for are cached for 12 hours.
@@ -1212,7 +1212,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/post_universe_ids
       def post_universe_ids_raw(names:, headers: {}, params: {})
-        post("/universe/ids/", headers: headers, params: params, payload: names)
+        post('/universe/ids/', headers: headers, params: params, payload: names)
       end
 
       # Resolve a set of IDs to names and categories. Supported ID's for resolving are: Characters, Corporations, Alliances, Stations, Solar Systems, Constellations, Regions, Types, Factions.
@@ -1233,7 +1233,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/post_universe_names
       def post_universe_names(ids:, headers: {}, params: {})
-        post_universe_names_raw(ids: ids, headers: headers, params: params).json
+        parse_response(post_universe_names_raw(ids: ids, headers: headers, params: params))
       end
 
       # Resolve a set of IDs to names and categories. Supported ID's for resolving are: Characters, Corporations, Alliances, Stations, Solar Systems, Constellations, Regions, Types, Factions.
@@ -1254,7 +1254,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Universe/post_universe_names
       def post_universe_names_raw(ids:, headers: {}, params: {})
-        post("/universe/names/", headers: headers, params: params, payload: ids)
+        post('/universe/names/', headers: headers, params: params, payload: ids)
       end
     end
   end

--- a/lib/esi/client/user_interface.rb
+++ b/lib/esi/client/user_interface.rb
@@ -30,7 +30,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_autopilot_waypoint
       def post_ui_autopilot_waypoint(add_to_beginning:, clear_other_waypoints:, destination_id:, headers: {}, params: {})
-        post_ui_autopilot_waypoint_raw(add_to_beginning: add_to_beginning, clear_other_waypoints: clear_other_waypoints, destination_id: destination_id, headers: headers, params: params).json
+        parse_response(post_ui_autopilot_waypoint_raw(add_to_beginning: add_to_beginning, clear_other_waypoints: clear_other_waypoints, destination_id: destination_id, headers: headers, params: params))
       end
 
       # Set a solar system as autopilot waypoint.
@@ -59,8 +59,8 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_autopilot_waypoint
       def post_ui_autopilot_waypoint_raw(add_to_beginning:, clear_other_waypoints:, destination_id:, headers: {}, params: {})
-        params.merge!("add_to_beginning" => add_to_beginning, "clear_other_waypoints" => clear_other_waypoints, "destination_id" => destination_id)
-        post("/ui/autopilot/waypoint/", headers: headers, params: params)
+        params.merge!('add_to_beginning' => add_to_beginning, 'clear_other_waypoints' => clear_other_waypoints, 'destination_id' => destination_id)
+        post('/ui/autopilot/waypoint/', headers: headers, params: params)
       end
 
       # Open the contract window inside the client.
@@ -87,7 +87,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_openwindow_contract
       def post_ui_openwindow_contract(contract_id:, headers: {}, params: {})
-        post_ui_openwindow_contract_raw(contract_id: contract_id, headers: headers, params: params).json
+        parse_response(post_ui_openwindow_contract_raw(contract_id: contract_id, headers: headers, params: params))
       end
 
       # Open the contract window inside the client.
@@ -114,8 +114,8 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_openwindow_contract
       def post_ui_openwindow_contract_raw(contract_id:, headers: {}, params: {})
-        params.merge!("contract_id" => contract_id)
-        post("/ui/openwindow/contract/", headers: headers, params: params)
+        params.merge!('contract_id' => contract_id)
+        post('/ui/openwindow/contract/', headers: headers, params: params)
       end
 
       # Open the information window for a character, corporation or alliance inside the client.
@@ -142,7 +142,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_openwindow_information
       def post_ui_openwindow_information(target_id:, headers: {}, params: {})
-        post_ui_openwindow_information_raw(target_id: target_id, headers: headers, params: params).json
+        parse_response(post_ui_openwindow_information_raw(target_id: target_id, headers: headers, params: params))
       end
 
       # Open the information window for a character, corporation or alliance inside the client.
@@ -169,8 +169,8 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_openwindow_information
       def post_ui_openwindow_information_raw(target_id:, headers: {}, params: {})
-        params.merge!("target_id" => target_id)
-        post("/ui/openwindow/information/", headers: headers, params: params)
+        params.merge!('target_id' => target_id)
+        post('/ui/openwindow/information/', headers: headers, params: params)
       end
 
       # Open the market details window for a specific typeID inside the client.
@@ -197,7 +197,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_openwindow_marketdetails
       def post_ui_openwindow_marketdetails(type_id:, headers: {}, params: {})
-        post_ui_openwindow_marketdetails_raw(type_id: type_id, headers: headers, params: params).json
+        parse_response(post_ui_openwindow_marketdetails_raw(type_id: type_id, headers: headers, params: params))
       end
 
       # Open the market details window for a specific typeID inside the client.
@@ -224,8 +224,8 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_openwindow_marketdetails
       def post_ui_openwindow_marketdetails_raw(type_id:, headers: {}, params: {})
-        params.merge!("type_id" => type_id)
-        post("/ui/openwindow/marketdetails/", headers: headers, params: params)
+        params.merge!('type_id' => type_id)
+        post('/ui/openwindow/marketdetails/', headers: headers, params: params)
       end
 
       # Open the New Mail window, according to settings from the request if applicable.
@@ -253,7 +253,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_openwindow_newmail
       def post_ui_openwindow_newmail(new_mail:, headers: {}, params: {})
-        post_ui_openwindow_newmail_raw(new_mail: new_mail, headers: headers, params: params).json
+        parse_response(post_ui_openwindow_newmail_raw(new_mail: new_mail, headers: headers, params: params))
       end
 
       # Open the New Mail window, according to settings from the request if applicable.
@@ -281,7 +281,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/User Interface/post_ui_openwindow_newmail
       def post_ui_openwindow_newmail_raw(new_mail:, headers: {}, params: {})
-        post("/ui/openwindow/newmail/", headers: headers, params: params, payload: new_mail)
+        post('/ui/openwindow/newmail/', headers: headers, params: params, payload: new_mail)
       end
     end
   end

--- a/lib/esi/client/wallet.rb
+++ b/lib/esi/client/wallet.rb
@@ -29,7 +29,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wallet/get_characters_character_id_wallet
       def get_character_wallet(character_id:, headers: {}, params: {})
-        get_character_wallet_raw(character_id: character_id, headers: headers, params: params).json
+        parse_response(get_character_wallet_raw(character_id: character_id, headers: headers, params: params))
       end
       alias get_characters_character_id_wallet get_character_wallet
 
@@ -145,7 +145,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wallet/get_characters_character_id_wallet_transactions
       def get_character_wallet_transactions(character_id:, from_id: nil, headers: {}, params: {})
-        get_character_wallet_transactions_raw(character_id: character_id, from_id: from_id, headers: headers, params: params).json
+        parse_response(get_character_wallet_transactions_raw(character_id: character_id, from_id: from_id, headers: headers, params: params))
       end
       alias get_characters_character_id_wallet_transactions get_character_wallet_transactions
 
@@ -176,7 +176,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wallet/get_characters_character_id_wallet_transactions
       def get_character_wallet_transactions_raw(character_id:, from_id: nil, headers: {}, params: {})
-        params.merge!("from_id" => from_id)
+        params.merge!('from_id' => from_id)
         get("/characters/#{character_id}/wallet/transactions/", headers: headers, params: params)
       end
 
@@ -206,7 +206,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wallet/get_corporations_corporation_id_wallets
       def get_corporation_wallets(corporation_id:, headers: {}, params: {})
-        get_corporation_wallets_raw(corporation_id: corporation_id, headers: headers, params: params).json
+        parse_response(get_corporation_wallets_raw(corporation_id: corporation_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_wallets get_corporation_wallets
 
@@ -326,7 +326,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wallet/get_corporations_corporation_id_wallets_division_transactions
       def get_corporation_wallets_division_transactions(corporation_id:, division:, from_id: nil, headers: {}, params: {})
-        get_corporation_wallets_division_transactions_raw(corporation_id: corporation_id, division: division, from_id: from_id, headers: headers, params: params).json
+        parse_response(get_corporation_wallets_division_transactions_raw(corporation_id: corporation_id, division: division, from_id: from_id, headers: headers, params: params))
       end
       alias get_corporations_corporation_id_wallets_division_transactions get_corporation_wallets_division_transactions
 
@@ -358,7 +358,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wallet/get_corporations_corporation_id_wallets_division_transactions
       def get_corporation_wallets_division_transactions_raw(corporation_id:, division:, from_id: nil, headers: {}, params: {})
-        params.merge!("from_id" => from_id)
+        params.merge!('from_id' => from_id)
         get("/corporations/#{corporation_id}/wallets/#{division}/transactions/", headers: headers, params: params)
       end
     end

--- a/lib/esi/client/wars.rb
+++ b/lib/esi/client/wars.rb
@@ -25,7 +25,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wars/get_wars_war_id
       def get_war(war_id:, headers: {}, params: {})
-        get_war_raw(war_id: war_id, headers: headers, params: params).json
+        parse_response(get_war_raw(war_id: war_id, headers: headers, params: params))
       end
       alias get_wars_war_id get_war
 
@@ -122,7 +122,7 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wars/get_wars
       def get_wars(max_war_id: nil, headers: {}, params: {})
-        get_wars_raw(max_war_id: max_war_id, headers: headers, params: params).json
+        parse_response(get_wars_raw(max_war_id: max_war_id, headers: headers, params: params))
       end
 
       # Return a list of wars.
@@ -145,8 +145,8 @@ module ESI
       #
       # @see https://esi.evetech.net/ui/#/Wars/get_wars
       def get_wars_raw(max_war_id: nil, headers: {}, params: {})
-        params.merge!("max_war_id" => max_war_id)
-        get("/wars/", headers: headers, params: params)
+        params.merge!('max_war_id' => max_war_id)
+        get('/wars/', headers: headers, params: params)
       end
     end
   end

--- a/lib/esi/version.rb
+++ b/lib/esi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ESI
-  VERSION = "2.1.3"
+  VERSION = '2.1.3'
 end

--- a/spec/integration/character_spec.rb
+++ b/spec/integration/character_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Character, type: :integration do
-  subject(:client) { ESI::Client.new(user_agent: "ESI SDK Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk)") }
+  subject(:client) { ESI::Client.new(user_agent: 'ESI SDK Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk)') }
 
-  describe "#get_character" do
-    it "returns the character" do
-      response = client.get_character(character_id: "2113024536")
-      expect(response["name"]).to eq("Bokobo Shahni")
+  describe '#get_character' do
+    it 'returns the character' do
+      response = client.get_character(character_id: '2113024536')
+      expect(response['name']).to eq('Bokobo Shahni')
     end
   end
 
-  describe "#post_character_affiliation" do
+  describe '#post_character_affiliation' do
     it "returns the character's affiliations" do
       response = client.post_characters_affiliation(characters: [2_113_024_536])
-      expect(response).to include("alliance_id" => 99_010_079, "character_id" => 2_113_024_536,
-                                  "corporation_id" => 98_613_799)
+      expect(response).to include('alliance_id' => 99_010_079, 'character_id' => 2_113_024_536,
+                                  'corporation_id' => 98_613_799)
     end
   end
 end

--- a/spec/integration/market_spec.rb
+++ b/spec/integration/market_spec.rb
@@ -3,11 +3,11 @@
 RSpec.describe ESI::Client::Market, type: :integration do
   subject(:client) { ESI::Client.new(user_agent: user_agent) }
 
-  let(:user_agent) { "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)" }
+  let(:user_agent) { 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)' }
 
-  describe "#get_markets_region_orders" do
-    it "automatically paginates get responses" do
-      response = client.get_markets_region_orders(region_id: "10000070")
+  describe '#get_markets_region_orders' do
+    it 'automatically paginates get responses' do
+      response = client.get_markets_region_orders(region_id: '10000070')
       expect(response.size).to be > 1000
     end
   end

--- a/spec/lib/esi-sdk_spec.rb
+++ b/spec/lib/esi-sdk_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI do
-  it "has a version number" do
+  it 'has a version number' do
     expect(ESI::VERSION).not_to be nil
   end
 end

--- a/spec/lib/esi/client/alliance_spec.rb
+++ b/spec/lib/esi/client/alliance_spec.rb
@@ -1,228 +1,60 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Alliance, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_alliance" do
-    context "when the response is 200" do
-      let(:response) { { "creator_corporation_id" => 45_678, "creator_id" => 12_345, "date_founded" => "2016-06-26T21:00:00Z", "executor_corporation_id" => 98_356_193, "name" => "C C P Alliance", "ticker" => "<C C P>" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_alliance(alliance_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_alliance' do
+    context 'when the response is 200' do
+      let(:response) { { 'creator_corporation_id' => 45_678, 'creator_id' => 12_345, 'date_founded' => '2016-06-26T21:00:00Z', 'executor_corporation_id' => 98_356_193, 'name' => 'C C P Alliance', 'ticker' => '<C C P>' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/alliances/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_alliance(alliance_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_alliance(alliance_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_alliance(alliance_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_alliance(alliance_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_alliance(alliance_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_alliance_corporations" do
-    context "when the response is 200" do
+  describe '#get_alliance_corporations' do
+    context 'when the response is 200' do
       let(:response) { [98_000_001] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/corporations/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/alliances/1234567890/corporations/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_alliance_corporations(alliance_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/corporations/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_alliance_corporations(alliance_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/corporations/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_alliance_corporations(alliance_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/corporations/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_alliance_corporations(alliance_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_alliance_corporations(alliance_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_alliance_icons" do
-    context "when the response is 200" do
-      let(:response) { { "px128x128" => "https://images.evetech.net/Alliance/503818424_128.png", "px64x64" => "https://images.evetech.net/Alliance/503818424_64.png" } }
+  describe '#get_alliance_icons' do
+    context 'when the response is 200' do
+      let(:response) { { 'px128x128' => 'https://images.evetech.net/Alliance/503818424_128.png', 'px64x64' => 'https://images.evetech.net/Alliance/503818424_64.png' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/icons/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/alliances/1234567890/icons/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_alliance_icons(alliance_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/icons/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_alliance_icons(alliance_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "No image server for this datasource" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/icons/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_alliance_icons(alliance_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/icons/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_alliance_icons(alliance_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/icons/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_alliance_icons(alliance_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_alliance_icons(alliance_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_alliances" do
-    context "when the response is 200" do
+  describe '#get_alliances' do
+    context 'when the response is 200' do
       let(:response) { [99_000_001, 99_000_002] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/alliances/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_alliances).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_alliances }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_alliances }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_alliances }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/assets_spec.rb
+++ b/spec/lib/esi/client/assets_spec.rb
@@ -1,484 +1,88 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Asset, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_assets" do
-    context "when the response is 200" do
-      let(:response) { [{ "is_blueprint_copy" => true, "is_singleton" => true, "item_id" => 1_000_000_016_835, "location_flag" => "Hangar", "location_id" => 60_002_959, "location_type" => "station", "quantity" => 1, "type_id" => 3516 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/assets/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_assets(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_assets' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'is_blueprint_copy' => true, 'is_singleton' => true, 'item_id' => 1_000_000_016_835, 'location_flag' => 'Hangar', 'location_id' => 60_002_959, 'location_type' => 'station', 'quantity' => 1, 'type_id' => 3516 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/assets/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/assets/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_assets(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/assets/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_assets(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/assets/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_assets(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Requested page does not exist" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/assets/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_assets(character_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/assets/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_assets(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/assets/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_assets(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_assets(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_assets" do
-    context "when the response is 200" do
-      let(:response) { [{ "is_blueprint_copy" => true, "is_singleton" => true, "item_id" => 1_000_000_016_835, "location_flag" => "Hangar", "location_id" => 60_002_959, "location_type" => "station", "quantity" => 1, "type_id" => 3516 }] }
+  describe '#get_corporation_assets' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'is_blueprint_copy' => true, 'is_singleton' => true, 'item_id' => 1_000_000_016_835, 'location_flag' => 'Hangar', 'location_id' => 60_002_959, 'location_type' => 'station', 'quantity' => 1, 'type_id' => 3516 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/assets/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/assets/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_assets(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/assets/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_assets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/assets/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_assets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/assets/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_assets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/assets/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_assets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/assets/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_assets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_assets(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_character_asset_locations" do
-    context "when the response is 200" do
-      let(:response) { [{ "item_id" => 12_345, "position" => { "x" => 1.2, "y" => 2.3, "z" => -3.4 } }] }
+  describe '#post_character_asset_locations' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'item_id' => 12_345, 'position' => { 'x' => 1.2, 'y' => 2.3, 'z' => -3.4 } }] }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/locations/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/characters/1234567890/assets/locations/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_character_asset_locations(character_id: "1234567890", item_ids: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/locations/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_character_asset_locations(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/locations/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_character_asset_locations(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/locations/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_character_asset_locations(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/locations/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_character_asset_locations(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/locations/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_character_asset_locations(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_character_asset_locations(character_id: '1234567890', item_ids: [1, 2, 3])).to eq(response)
       end
     end
   end
 
-  describe "#post_character_asset_names" do
-    context "when the response is 200" do
-      let(:response) { [{ "item_id" => 12_345, "name" => "Awesome Name" }] }
+  describe '#post_character_asset_names' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'item_id' => 12_345, 'name' => 'Awesome Name' }] }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/names/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/characters/1234567890/assets/names/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_character_asset_names(character_id: "1234567890", item_ids: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/names/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_character_asset_names(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/names/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_character_asset_names(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/names/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_character_asset_names(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/names/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_character_asset_names(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/assets/names/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_character_asset_names(character_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_character_asset_names(character_id: '1234567890', item_ids: [1, 2, 3])).to eq(response)
       end
     end
   end
 
-  describe "#post_corporation_asset_locations" do
-    context "when the response is 200" do
-      let(:response) { [{ "item_id" => 12_345, "position" => { "x" => 1.2, "y" => 2.3, "z" => -3.4 } }] }
+  describe '#post_corporation_asset_locations' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'item_id' => 12_345, 'position' => { 'x' => 1.2, 'y' => 2.3, 'z' => -3.4 } }] }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/locations/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/corporations/1234567890/assets/locations/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_corporation_asset_locations(corporation_id: "1234567890", item_ids: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/locations/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_corporation_asset_locations(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/locations/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_corporation_asset_locations(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/locations/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_corporation_asset_locations(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/locations/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.post_corporation_asset_locations(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/locations/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_corporation_asset_locations(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/locations/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_corporation_asset_locations(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_corporation_asset_locations(corporation_id: '1234567890', item_ids: [1, 2, 3])).to eq(response)
       end
     end
   end
 
-  describe "#post_corporation_asset_names" do
-    context "when the response is 200" do
-      let(:response) { [{ "item_id" => 12_345, "name" => "Awesome Name" }] }
+  describe '#post_corporation_asset_names' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'item_id' => 12_345, 'name' => 'Awesome Name' }] }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/names/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/corporations/1234567890/assets/names/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_corporation_asset_names(corporation_id: "1234567890", item_ids: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/names/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_corporation_asset_names(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/names/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_corporation_asset_names(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/names/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_corporation_asset_names(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/names/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.post_corporation_asset_names(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/names/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_corporation_asset_names(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/corporations/1234567890/assets/names/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_corporation_asset_names(corporation_id: "1234567890", item_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_corporation_asset_names(corporation_id: '1234567890', item_ids: [1, 2, 3])).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/bookmarks_spec.rb
+++ b/spec/lib/esi/client/bookmarks_spec.rb
@@ -1,300 +1,60 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Bookmark, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_bookmark_folders" do
-    context "when the response is 200" do
-      let(:response) { [{ "folder_id" => 5, "name" => "Icecream" }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/folders/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_bookmark_folders(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_bookmark_folders' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'folder_id' => 5, 'name' => 'Icecream' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/bookmarks/folders/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_bookmark_folders(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_bookmark_folders(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_bookmark_folders(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_bookmark_folders(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_bookmark_folders(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_bookmark_folders(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_bookmarks" do
-    context "when the response is 200" do
-      let(:response) { [{ "bookmark_id" => 4, "created" => "2016-08-09T11:57:47Z", "creator_id" => 2_112_625_428, "folder_id" => 5, "item" => { "item_id" => 50_006_722, "type_id" => 29_633 }, "label" => "Stargate", "location_id" => 30_003_430, "notes" => "This is a stargate" }, { "bookmark_id" => 5, "coordinates" => { "x" => -2_958_928_814_000, "y" => -338_367_275_823, "z" => 2_114_538_075_090 }, "created" => "2016-08-09T11:57:47Z", "creator_id" => 2_112_625_428, "folder_id" => 5, "label" => "Random location", "location_id" => 30_003_430, "notes" => "This is a random location in space" }] }
+  describe '#get_character_bookmarks' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'bookmark_id' => 4, 'created' => '2016-08-09T11:57:47Z', 'creator_id' => 2_112_625_428, 'folder_id' => 5, 'item' => { 'item_id' => 50_006_722, 'type_id' => 29_633 }, 'label' => 'Stargate', 'location_id' => 30_003_430, 'notes' => 'This is a stargate' }, { 'bookmark_id' => 5, 'coordinates' => { 'x' => -2_958_928_814_000, 'y' => -338_367_275_823, 'z' => 2_114_538_075_090 }, 'created' => '2016-08-09T11:57:47Z', 'creator_id' => 2_112_625_428, 'folder_id' => 5, 'label' => 'Random location', 'location_id' => 30_003_430, 'notes' => 'This is a random location in space' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/bookmarks/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_bookmarks(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_bookmarks(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_bookmarks(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_bookmarks(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_bookmarks(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/bookmarks/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_bookmarks(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_bookmarks(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_bookmark_folders" do
-    context "when the response is 200" do
-      let(:response) { [{ "folder_id" => 5, "name" => "Important Locations" }] }
+  describe '#get_corporation_bookmark_folders' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'folder_id' => 5, 'name' => 'Important Locations' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/folders/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/bookmarks/folders/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_bookmark_folders(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_bookmark_folders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_bookmark_folders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_bookmark_folders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_bookmark_folders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/folders/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_bookmark_folders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_bookmark_folders(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_bookmarks" do
-    context "when the response is 200" do
-      let(:response) { [{ "bookmark_id" => 4, "created" => "2016-08-09T11:57:47Z", "creator_id" => 2_112_625_428, "folder_id" => 5, "item" => { "item_id" => 50_006_722, "type_id" => 29_633 }, "label" => "Stargate", "location_id" => 30_003_430, "notes" => "This is a stargate" }, { "bookmark_id" => 5, "coordinates" => { "x" => -2_958_928_814_000, "y" => -338_367_275_823, "z" => 2_114_538_075_090 }, "created" => "2016-08-09T11:57:47Z", "creator_id" => 2_112_625_428, "folder_id" => 5, "label" => "Random location", "location_id" => 30_003_430, "notes" => "This is a random location in space" }] }
+  describe '#get_corporation_bookmarks' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'bookmark_id' => 4, 'created' => '2016-08-09T11:57:47Z', 'creator_id' => 2_112_625_428, 'folder_id' => 5, 'item' => { 'item_id' => 50_006_722, 'type_id' => 29_633 }, 'label' => 'Stargate', 'location_id' => 30_003_430, 'notes' => 'This is a stargate' }, { 'bookmark_id' => 5, 'coordinates' => { 'x' => -2_958_928_814_000, 'y' => -338_367_275_823, 'z' => 2_114_538_075_090 }, 'created' => '2016-08-09T11:57:47Z', 'creator_id' => 2_112_625_428, 'folder_id' => 5, 'label' => 'Random location', 'location_id' => 30_003_430, 'notes' => 'This is a random location in space' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/bookmarks/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_bookmarks(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_bookmarks(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_bookmarks(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_bookmarks(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_bookmarks(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/bookmarks/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_bookmarks(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_bookmarks(corporation_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/calendar_spec.rb
+++ b/spec/lib/esi/client/calendar_spec.rb
@@ -1,324 +1,60 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Calendar, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_calendar" do
-    context "when the response is 200" do
-      let(:response) { [{ "event_date" => "2016-06-26T20:00:00Z", "event_id" => 1_386_435, "event_response" => "accepted", "importance" => 0, "title" => "o7 The EVE Online Show" }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/").with(query: { from_event: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_calendar(character_id: "1234567890", from_event: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_calendar' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'event_date' => '2016-06-26T20:00:00Z', 'event_id' => 1_386_435, 'event_response' => 'accepted', 'importance' => 0, 'title' => 'o7 The EVE Online Show' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/").with(query: { from_event: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/calendar/').with(query: { from_event: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_calendar(character_id: "1234567890", from_event: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/").with(query: { from_event: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_calendar(character_id: "1234567890", from_event: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/").with(query: { from_event: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_calendar(character_id: "1234567890", from_event: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/").with(query: { from_event: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_calendar(character_id: "1234567890", from_event: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/").with(query: { from_event: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_calendar(character_id: "1234567890", from_event: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_calendar(character_id: '1234567890', from_event: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_calendar_event" do
-    context "when the response is 200" do
-      let(:response) { { "date" => "2016-06-26T21:00:00Z", "duration" => 60, "event_id" => 1_386_435, "importance" => 1, "owner_id" => 1, "owner_name" => "EVE System", "owner_type" => "eve_server", "response" => "Undecided", "text" => "o7: The EVE Online Show features latest developer news, fast paced action, community overviews and a lot more with CCP Guard and CCP Mimic. Join the thrilling o7 live broadcast at 20:00 EVE time (=UTC) on <a href=\"http://www.twitch.tv/ccp\">EVE TV</a>. Don't miss it!", "title" => "o7 The EVE Online Show" } }
+  describe '#get_character_calendar_event' do
+    context 'when the response is 200' do
+      let(:response) { { 'date' => '2016-06-26T21:00:00Z', 'duration' => 60, 'event_id' => 1_386_435, 'importance' => 1, 'owner_id' => 1, 'owner_name' => 'EVE System', 'owner_type' => 'eve_server', 'response' => 'Undecided', 'text' => "o7: The EVE Online Show features latest developer news, fast paced action, community overviews and a lot more with CCP Guard and CCP Mimic. Join the thrilling o7 live broadcast at 20:00 EVE time (=UTC) on <a href=\"http://www.twitch.tv/ccp\">EVE TV</a>. Don't miss it!", 'title' => 'o7 The EVE Online Show' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_calendar_event(character_id: "1234567890", event_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_calendar_event(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_calendar_event(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_calendar_event(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_calendar_event(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_calendar_event(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_calendar_event(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_calendar_event(character_id: '1234567890', event_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_calendar_event_attendees" do
-    context "when the response is 200" do
-      let(:response) { [{ "character_id" => 2_112_625_428, "event_response" => "accepted" }, { "character_id" => 95_465_499, "event_response" => "tentative" }] }
+  describe '#get_character_calendar_event_attendees' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'character_id' => 2_112_625_428, 'event_response' => 'accepted' }, { 'character_id' => 95_465_499, 'event_response' => 'tentative' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/attendees/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/attendees/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_calendar_event_attendees(character_id: "1234567890", event_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/attendees/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_calendar_event_attendees(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/attendees/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_calendar_event_attendees(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/attendees/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_calendar_event_attendees(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/attendees/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_calendar_event_attendees(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/attendees/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_calendar_event_attendees(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/attendees/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_calendar_event_attendees(character_id: "1234567890", event_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_calendar_event_attendees(character_id: '1234567890', event_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#put_character_calendar_event" do
-    context "when the response is 204" do
+  describe '#put_character_calendar_event' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:put, 'https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.put_character_calendar_event(character_id: "1234567890", event_id: "1234567890", response: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.put_character_calendar_event(character_id: "1234567890", event_id: "1234567890", response: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.put_character_calendar_event(character_id: "1234567890", event_id: "1234567890", response: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.put_character_calendar_event(character_id: "1234567890", event_id: "1234567890", response: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.put_character_calendar_event(character_id: "1234567890", event_id: "1234567890", response: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/calendar/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.put_character_calendar_event(character_id: "1234567890", event_id: "1234567890", response: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.put_character_calendar_event(character_id: '1234567890', event_id: '1234567890', response: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/character_spec.rb
+++ b/spec/lib/esi/client/character_spec.rb
@@ -1,968 +1,200 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Character, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character" do
-    context "when the response is 200" do
-      let(:response) { { "birthday" => "2015-03-24T11:37:00Z", "bloodline_id" => 3, "corporation_id" => 109_299_958, "description" => "", "gender" => "male", "name" => "CCP Bartender", "race_id" => 2, "title" => "All round pretty awesome guy" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character' do
+    context 'when the response is 200' do
+      let(:response) { { 'birthday' => '2015-03-24T11:37:00Z', 'bloodline_id' => 3, 'corporation_id' => 109_299_958, 'description' => '', 'gender' => 'male', 'name' => 'CCP Bartender', 'race_id' => 2, 'title' => 'All round pretty awesome guy' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character(character_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_agents_research" do
-    context "when the response is 200" do
-      let(:response) { [{ "agent_id" => 3_009_358, "points_per_day" => 53.5346162146776, "remainder_points" => 53_604.0634303189, "skill_type_id" => 11_450, "started_at" => "2017-03-23T14:47:00Z" }] }
+  describe '#get_character_agents_research' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'agent_id' => 3_009_358, 'points_per_day' => 53.5346162146776, 'remainder_points' => 53_604.0634303189, 'skill_type_id' => 11_450, 'started_at' => '2017-03-23T14:47:00Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/agents_research/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/agents_research/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_agents_research(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/agents_research/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_agents_research(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/agents_research/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_agents_research(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/agents_research/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_agents_research(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/agents_research/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_agents_research(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/agents_research/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_agents_research(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_agents_research(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_blueprints" do
-    context "when the response is 200" do
-      let(:response) { [{ "item_id" => 1_000_000_010_495, "location_flag" => "Hangar", "location_id" => 60_014_719, "material_efficiency" => 0, "quantity" => 1, "runs" => -1, "time_efficiency" => 0, "type_id" => 691 }] }
+  describe '#get_character_blueprints' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'item_id' => 1_000_000_010_495, 'location_flag' => 'Hangar', 'location_id' => 60_014_719, 'material_efficiency' => 0, 'quantity' => 1, 'runs' => -1, 'time_efficiency' => 0, 'type_id' => 691 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/blueprints/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/blueprints/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_blueprints(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/blueprints/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_blueprints(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/blueprints/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_blueprints(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/blueprints/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_blueprints(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/blueprints/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_blueprints(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/blueprints/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_blueprints(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_blueprints(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_corporationhistory" do
-    context "when the response is 200" do
-      let(:response) { [{ "corporation_id" => 90_000_001, "is_deleted" => true, "record_id" => 500, "start_date" => "2016-06-26T20:00:00Z" }, { "corporation_id" => 90_000_002, "record_id" => 501, "start_date" => "2016-07-26T20:00:00Z" }] }
+  describe '#get_character_corporationhistory' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'corporation_id' => 90_000_001, 'is_deleted' => true, 'record_id' => 500, 'start_date' => '2016-06-26T20:00:00Z' }, { 'corporation_id' => 90_000_002, 'record_id' => 501, 'start_date' => '2016-07-26T20:00:00Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/corporationhistory/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/corporationhistory/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_corporationhistory(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/corporationhistory/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_corporationhistory(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/corporationhistory/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_corporationhistory(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/corporationhistory/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_corporationhistory(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_corporationhistory(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_fatigue" do
-    context "when the response is 200" do
-      let(:response) { { "jump_fatigue_expire_date" => "2017-07-06T15:47:00Z", "last_jump_date" => "2017-07-05T15:47:00Z", "last_update_date" => "2017-07-05T15:42:00Z" } }
+  describe '#get_character_fatigue' do
+    context 'when the response is 200' do
+      let(:response) { { 'jump_fatigue_expire_date' => '2017-07-06T15:47:00Z', 'last_jump_date' => '2017-07-05T15:47:00Z', 'last_update_date' => '2017-07-05T15:42:00Z' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fatigue/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/fatigue/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_fatigue(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fatigue/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_fatigue(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fatigue/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_fatigue(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fatigue/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_fatigue(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fatigue/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_fatigue(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fatigue/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_fatigue(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_fatigue(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_medals" do
-    context "when the response is 200" do
-      let(:response) { [{ "corporation_id" => 98_000_001, "date" => "2017-03-16T15:01:45Z", "description" => "For 33 corp!", "graphics" => [{ "color" => -1, "graphic" => "caldari.1_1", "layer" => 0, "part" => 1 }, { "color" => -330_271, "graphic" => "caldari.1_2", "layer" => 1, "part" => 1 }, { "color" => -1, "graphic" => "compass.1_2", "layer" => 0, "part" => 2 }], "issuer_id" => 2_112_000_002, "medal_id" => 3, "reason" => "Thanks!", "status" => "private", "title" => "33 tester medal" }] }
+  describe '#get_character_medals' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'corporation_id' => 98_000_001, 'date' => '2017-03-16T15:01:45Z', 'description' => 'For 33 corp!', 'graphics' => [{ 'color' => -1, 'graphic' => 'caldari.1_1', 'layer' => 0, 'part' => 1 }, { 'color' => -330_271, 'graphic' => 'caldari.1_2', 'layer' => 1, 'part' => 1 }, { 'color' => -1, 'graphic' => 'compass.1_2', 'layer' => 0, 'part' => 2 }], 'issuer_id' => 2_112_000_002, 'medal_id' => 3, 'reason' => 'Thanks!', 'status' => 'private', 'title' => '33 tester medal' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/medals/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/medals/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_medals(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/medals/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_medals(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/medals/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_medals(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/medals/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_medals(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/medals/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_medals(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/medals/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_medals(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_medals(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_notification_contacts" do
-    context "when the response is 200" do
-      let(:response) { [{ "message" => "hello friend :3", "notification_id" => 1, "send_date" => "2017-08-16T10:08:00Z", "sender_character_id" => 95_465_499, "standing_level" => 1.5 }] }
+  describe '#get_character_notification_contacts' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'message' => 'hello friend :3', 'notification_id' => 1, 'send_date' => '2017-08-16T10:08:00Z', 'sender_character_id' => 95_465_499, 'standing_level' => 1.5 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/contacts/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/notifications/contacts/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_notification_contacts(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/contacts/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_notification_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/contacts/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_notification_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/contacts/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_notification_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/contacts/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_notification_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/contacts/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_notification_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_notification_contacts(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_notifications" do
-    context "when the response is 200" do
-      let(:response) { [{ "is_read" => true, "notification_id" => 1, "sender_id" => 1_000_132, "sender_type" => "corporation", "text" => "amount: 3731016.4000000004\\nitemID: 1024881021663\\npayout: 1\\n", "timestamp" => "2017-08-16T10:08:00Z", "type" => "InsurancePayoutMsg" }] }
+  describe '#get_character_notifications' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'is_read' => true, 'notification_id' => 1, 'sender_id' => 1_000_132, 'sender_type' => 'corporation', 'text' => 'amount: 3731016.4000000004\\nitemID: 1024881021663\\npayout: 1\\n', 'timestamp' => '2017-08-16T10:08:00Z', 'type' => 'InsurancePayoutMsg' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/notifications/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_notifications(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_notifications(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_notifications(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_notifications(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_notifications(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/notifications/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_notifications(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_notifications(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_portrait" do
-    context "when the response is 200" do
-      let(:response) { { "px128x128" => "https://images.evetech.net/characters/95465499/portrait?tenant=tranquility&size=128", "px256x256" => "https://images.evetech.net/characters/95465499/portrait?tenant=tranquility&size=256", "px512x512" => "https://images.evetech.net/characters/95465499/portrait?tenant=tranquility&size=512", "px64x64" => "https://images.evetech.net/characters/95465499/portrait?tenant=tranquility&size=64" } }
+  describe '#get_character_portrait' do
+    context 'when the response is 200' do
+      let(:response) { { 'px128x128' => 'https://images.evetech.net/characters/95465499/portrait?tenant=tranquility&size=128', 'px256x256' => 'https://images.evetech.net/characters/95465499/portrait?tenant=tranquility&size=256', 'px512x512' => 'https://images.evetech.net/characters/95465499/portrait?tenant=tranquility&size=512', 'px64x64' => 'https://images.evetech.net/characters/95465499/portrait?tenant=tranquility&size=64' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/portrait/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/portrait/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_portrait(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/portrait/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_portrait(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "No image server for this datasource" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/portrait/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_portrait(character_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/portrait/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_portrait(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/portrait/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_portrait(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_portrait(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_roles" do
-    context "when the response is 200" do
-      let(:response) { { "roles" => %w[Director Station_Manager] } }
+  describe '#get_character_roles' do
+    context 'when the response is 200' do
+      let(:response) { { 'roles' => %w[Director Station_Manager] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/roles/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/roles/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_roles(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/roles/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_roles(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/roles/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_roles(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/roles/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_roles(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/roles/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_roles(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/roles/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_roles(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_roles(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_standings" do
-    context "when the response is 200" do
-      let(:response) { [{ "from_id" => 3_009_841, "from_type" => "agent", "standing" => 0.1 }, { "from_id" => 1_000_061, "from_type" => "npc_corp", "standing" => 0 }, { "from_id" => 500_003, "from_type" => "faction", "standing" => -1 }] }
+  describe '#get_character_standings' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'from_id' => 3_009_841, 'from_type' => 'agent', 'standing' => 0.1 }, { 'from_id' => 1_000_061, 'from_type' => 'npc_corp', 'standing' => 0 }, { 'from_id' => 500_003, 'from_type' => 'faction', 'standing' => -1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/standings/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/standings/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_standings(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/standings/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_standings(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/standings/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_standings(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/standings/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_standings(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/standings/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_standings(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/standings/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_standings(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_standings(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_titles" do
-    context "when the response is 200" do
-      let(:response) { [{ "name" => "Awesome Title", "title_id" => 1 }] }
+  describe '#get_character_titles' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'name' => 'Awesome Title', 'title_id' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/titles/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/titles/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_titles(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/titles/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_titles(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/titles/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_titles(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/titles/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_titles(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/titles/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_titles(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/titles/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_titles(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_titles(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_character_cspa" do
-    context "when the response is 201" do
+  describe '#post_character_cspa' do
+    context 'when the response is 201' do
       let(:response) { 2950.0 }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/cspa/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/characters/1234567890/cspa/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_character_cspa(character_id: "1234567890", characters: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/cspa/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_character_cspa(character_id: "1234567890", characters: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/cspa/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_character_cspa(character_id: "1234567890", characters: [1, 2, 3]) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/cspa/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_character_cspa(character_id: "1234567890", characters: [1, 2, 3]) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/cspa/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_character_cspa(character_id: "1234567890", characters: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/cspa/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_character_cspa(character_id: "1234567890", characters: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_character_cspa(character_id: '1234567890', characters: [1, 2, 3])).to eq(response)
       end
     end
   end
 
-  describe "#post_characters_affiliation" do
-    context "when the response is 200" do
-      let(:response) { [{ "alliance_id" => 434_243_723, "character_id" => 95_538_921, "corporation_id" => 109_299_958 }] }
+  describe '#post_characters_affiliation' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'alliance_id' => 434_243_723, 'character_id' => 95_538_921, 'corporation_id' => 109_299_958 }] }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/affiliation/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/characters/affiliation/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.post_characters_affiliation(characters: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/affiliation/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_characters_affiliation(characters: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/affiliation/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_characters_affiliation(characters: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/affiliation/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_characters_affiliation(characters: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/clones_spec.rb
+++ b/spec/lib/esi/client/clones_spec.rb
@@ -1,152 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Clone, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_clones" do
-    context "when the response is 200" do
-      let(:response) { { "home_location" => { "location_id" => 1_021_348_135_816, "location_type" => "structure" }, "jump_clones" => [{ "implants" => [22_118], "jump_clone_id" => 12_345, "location_id" => 60_003_463, "location_type" => "station" }] } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/clones/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_clones(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_clones' do
+    context 'when the response is 200' do
+      let(:response) { { 'home_location' => { 'location_id' => 1_021_348_135_816, 'location_type' => 'structure' }, 'jump_clones' => [{ 'implants' => [22_118], 'jump_clone_id' => 12_345, 'location_id' => 60_003_463, 'location_type' => 'station' }] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/clones/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/clones/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_clones(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/clones/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_clones(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/clones/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_clones(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/clones/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_clones(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/clones/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_clones(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_clones(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_implants" do
-    context "when the response is 200" do
+  describe '#get_character_implants' do
+    context 'when the response is 200' do
       let(:response) { [1, 2, 3] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/implants/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/implants/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_implants(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/implants/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_implants(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/implants/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_implants(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/implants/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_implants(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/implants/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_implants(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/implants/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_implants(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_implants(character_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/contacts_spec.rb
+++ b/spec/lib/esi/client/contacts_spec.rb
@@ -1,682 +1,130 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Contact, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#delete_character_contacts" do
-    context "when the response is 204" do
+  describe '#delete_character_contacts' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { contact_ids: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:delete, 'https://esi.evetech.net/latest/characters/1234567890/contacts/').with(query: { contact_ids: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.delete_character_contacts(character_id: "1234567890", contact_ids: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { contact_ids: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.delete_character_contacts(character_id: "1234567890", contact_ids: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { contact_ids: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.delete_character_contacts(character_id: "1234567890", contact_ids: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { contact_ids: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.delete_character_contacts(character_id: "1234567890", contact_ids: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { contact_ids: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.delete_character_contacts(character_id: "1234567890", contact_ids: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { contact_ids: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.delete_character_contacts(character_id: "1234567890", contact_ids: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.delete_character_contacts(character_id: '1234567890', contact_ids: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_alliance_contact_labels" do
-    context "when the response is 200" do
-      let(:response) { [{ "label_id" => 1, "label_name" => "Alliance Friends" }] }
+  describe '#get_alliance_contact_labels' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'label_id' => 1, 'label_name' => 'Alliance Friends' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/labels/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/alliances/1234567890/contacts/labels/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_alliance_contact_labels(alliance_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/labels/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_alliance_contact_labels(alliance_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/labels/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_alliance_contact_labels(alliance_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/labels/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_alliance_contact_labels(alliance_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/labels/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_alliance_contact_labels(alliance_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/labels/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_alliance_contact_labels(alliance_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_alliance_contact_labels(alliance_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_alliance_contacts" do
-    context "when the response is 200" do
-      let(:response) { [{ "contact_id" => 2_112_625_428, "contact_type" => "character", "standing" => 9.9 }] }
+  describe '#get_alliance_contacts' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'contact_id' => 2_112_625_428, 'contact_type' => 'character', 'standing' => 9.9 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/alliances/1234567890/contacts/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_alliance_contacts(alliance_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_alliance_contacts(alliance_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_alliance_contacts(alliance_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_alliance_contacts(alliance_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_alliance_contacts(alliance_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/alliances/1234567890/contacts/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_alliance_contacts(alliance_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_alliance_contacts(alliance_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_contact_labels" do
-    context "when the response is 200" do
-      let(:response) { [{ "label_id" => 123, "label_name" => "Friends" }] }
+  describe '#get_character_contact_labels' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'label_id' => 123, 'label_name' => 'Friends' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/labels/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/contacts/labels/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_contact_labels(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/labels/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_contact_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/labels/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_contact_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/labels/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_contact_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/labels/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_contact_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/labels/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_contact_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_contact_labels(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_contacts" do
-    context "when the response is 200" do
-      let(:response) { [{ "contact_id" => 123, "contact_type" => "character", "is_blocked" => true, "is_watched" => true, "standing" => 9.9 }] }
+  describe '#get_character_contacts' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'contact_id' => 123, 'contact_type' => 'character', 'is_blocked' => true, 'is_watched' => true, 'standing' => 9.9 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/contacts/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_contacts(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contacts/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_contacts(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_contacts(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_contact_labels" do
-    context "when the response is 200" do
-      let(:response) { [{ "label_id" => 2, "label_name" => "Corporation Friends" }] }
+  describe '#get_corporation_contact_labels' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'label_id' => 2, 'label_name' => 'Corporation Friends' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/labels/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/contacts/labels/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_contact_labels(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/labels/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_contact_labels(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/labels/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_contact_labels(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/labels/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_contact_labels(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/labels/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_contact_labels(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/labels/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_contact_labels(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_contact_labels(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_contacts" do
-    context "when the response is 200" do
-      let(:response) { [{ "contact_id" => 123, "contact_type" => "character", "is_watched" => true, "standing" => 9.9 }] }
+  describe '#get_corporation_contacts' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'contact_id' => 123, 'contact_type' => 'character', 'is_watched' => true, 'standing' => 9.9 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/contacts/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_contacts(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_contacts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_contacts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_contacts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_contacts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contacts/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_contacts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_contacts(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_character_contacts" do
-    context "when the response is 201" do
+  describe '#post_character_contacts' do
+    context 'when the response is 201' do
       let(:response) { [123, 456] }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/characters/1234567890/contacts/').with(query: { label_ids: '1234567890', standing: '1234567890', watched: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-
-    context "when the response is 520" do
-      let(:response) { { "error" => "Error 520 message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 520, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::EveServerError error" do
-        expect { client.post_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::EveServerError)
+      it 'returns the response' do
+        expect(client.post_character_contacts(character_id: '1234567890', label_ids: '1234567890', standing: '1234567890', watched: '1234567890', contact_ids: [1, 2, 3])).to eq(response)
       end
     end
   end
 
-  describe "#put_character_contacts" do
-    context "when the response is 204" do
+  describe '#put_character_contacts' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:put, 'https://esi.evetech.net/latest/characters/1234567890/contacts/').with(query: { label_ids: '1234567890', standing: '1234567890', watched: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.put_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.put_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.put_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.put_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.put_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/contacts/").with(query: { label_ids: "1234567890", standing: "1234567890", watched: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.put_character_contacts(character_id: "1234567890", label_ids: "1234567890", standing: "1234567890", watched: "1234567890", contact_ids: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.put_character_contacts(character_id: '1234567890', label_ids: '1234567890', standing: '1234567890', watched: '1234567890', contact_ids: [1, 2, 3])).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/contracts_spec.rb
+++ b/spec/lib/esi/client/contracts_spec.rb
@@ -1,718 +1,130 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Contract, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_contract_bids" do
-    context "when the response is 200" do
-      let(:response) { [{ "amount" => 1.23, "bid_id" => 1, "bidder_id" => 123, "date_bid" => "2017-01-01T10:10:10Z" }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_contract_bids(character_id: "1234567890", contract_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_contract_bids' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'amount' => 1.23, 'bid_id' => 1, 'bidder_id' => 123, 'date_bid' => '2017-01-01T10:10:10Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/bids/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_contract_bids(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_contract_bids(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_contract_bids(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_contract_bids(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_contract_bids(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_contract_bids(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_contract_bids(character_id: '1234567890', contract_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_contract_items" do
-    context "when the response is 200" do
-      let(:response) { [{ "is_included" => true, "is_singleton" => false, "quantity" => 1, "record_id" => 123_456, "type_id" => 587 }] }
+  describe '#get_character_contract_items' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'is_included' => true, 'is_singleton' => false, 'quantity' => 1, 'record_id' => 123_456, 'type_id' => 587 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/items/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_contract_items(character_id: "1234567890", contract_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_contract_items(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_contract_items(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_contract_items(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_contract_items(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_contract_items(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_contract_items(character_id: "1234567890", contract_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_contract_items(character_id: '1234567890', contract_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_contracts" do
-    context "when the response is 200" do
-      let(:response) { [{ "acceptor_id" => 0, "assignee_id" => 0, "availability" => "public", "buyout" => 10_000_000_000.01, "contract_id" => 1, "date_accepted" => "2017-06-06T13:12:32Z", "date_completed" => "2017-06-06T13:12:32Z", "date_expired" => "2017-06-13T13:12:32Z", "date_issued" => "2017-06-06T13:12:32Z", "days_to_complete" => 0, "end_location_id" => 60_014_719, "for_corporation" => true, "issuer_corporation_id" => 456, "issuer_id" => 123, "price" => 1_000_000.01, "reward" => 0.01, "start_location_id" => 60_014_719, "status" => "outstanding", "type" => "auction", "volume" => 0.01 }] }
+  describe '#get_character_contracts' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'acceptor_id' => 0, 'assignee_id' => 0, 'availability' => 'public', 'buyout' => 10_000_000_000.01, 'contract_id' => 1, 'date_accepted' => '2017-06-06T13:12:32Z', 'date_completed' => '2017-06-06T13:12:32Z', 'date_expired' => '2017-06-13T13:12:32Z', 'date_issued' => '2017-06-06T13:12:32Z', 'days_to_complete' => 0, 'end_location_id' => 60_014_719, 'for_corporation' => true, 'issuer_corporation_id' => 456, 'issuer_id' => 123, 'price' => 1_000_000.01, 'reward' => 0.01, 'start_location_id' => 60_014_719, 'status' => 'outstanding', 'type' => 'auction', 'volume' => 0.01 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/contracts/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_contracts(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_contracts(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_contracts(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_contracts(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_contracts(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/contracts/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_contracts(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_contracts(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_contracts_public_bids_contract" do
-    context "when the response is 200" do
-      let(:response) { [{ "amount" => 1.23, "bid_id" => 1, "date_bid" => "2017-01-01T10:10:10Z" }] }
+  describe '#get_contracts_public_bids_contract' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'amount' => 1.23, 'bid_id' => 1, 'date_bid' => '2017-01-01T10:10:10Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/bids/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/contracts/public/bids/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_contracts_public_bids_contract(contract_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/bids/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_contracts_public_bids_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/bids/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_contracts_public_bids_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/bids/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_contracts_public_bids_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/bids/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_contracts_public_bids_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/bids/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_contracts_public_bids_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_contracts_public_bids_contract(contract_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_contracts_public_items_contract" do
-    context "when the response is 200" do
-      let(:response) { [{ "is_included" => true, "item_id" => 123_456, "quantity" => 1, "record_id" => 123_456, "type_id" => 587 }] }
+  describe '#get_contracts_public_items_contract' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'is_included' => true, 'item_id' => 123_456, 'quantity' => 1, 'record_id' => 123_456, 'type_id' => 587 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/items/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/contracts/public/items/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_contracts_public_items_contract(contract_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/items/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_contracts_public_items_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/items/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_contracts_public_items_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/items/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_contracts_public_items_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/items/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_contracts_public_items_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/items/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_contracts_public_items_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_contracts_public_items_contract(contract_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_contracts_public_region" do
-    context "when the response is 200" do
-      let(:response) { [{ "buyout" => 10_000_000_000.01, "contract_id" => 1, "date_expired" => "2017-06-13T13:12:32Z", "date_issued" => "2017-06-06T13:12:32Z", "days_to_complete" => 0, "end_location_id" => 60_014_719, "for_corporation" => true, "issuer_corporation_id" => 456, "issuer_id" => 123, "price" => 1_000_000.01, "reward" => 0.01, "start_location_id" => 60_014_719, "type" => "auction", "volume" => 0.01 }] }
+  describe '#get_contracts_public_region' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'buyout' => 10_000_000_000.01, 'contract_id' => 1, 'date_expired' => '2017-06-13T13:12:32Z', 'date_issued' => '2017-06-06T13:12:32Z', 'days_to_complete' => 0, 'end_location_id' => 60_014_719, 'for_corporation' => true, 'issuer_corporation_id' => 456, 'issuer_id' => 123, 'price' => 1_000_000.01, 'reward' => 0.01, 'start_location_id' => 60_014_719, 'type' => 'auction', 'volume' => 0.01 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/contracts/public/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_contracts_public_region(region_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_contracts_public_region(region_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_contracts_public_region(region_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_contracts_public_region(region_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/contracts/public/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_contracts_public_region(region_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_contracts_public_region(region_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_contract_bids" do
-    context "when the response is 200" do
-      let(:response) { [{ "amount" => 1.23, "bid_id" => 1, "bidder_id" => 123, "date_bid" => "2017-01-01T10:10:10Z" }] }
+  describe '#get_corporation_contract_bids' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'amount' => 1.23, 'bid_id' => 1, 'bidder_id' => 123, 'date_bid' => '2017-01-01T10:10:10Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/bids/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_contract_bids(contract_id: "1234567890", corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_contract_bids(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_contract_bids(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_contract_bids(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_corporation_contract_bids(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_contract_bids(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/bids/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_contract_bids(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_contract_bids(contract_id: '1234567890', corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_contract_items" do
-    context "when the response is 200" do
-      let(:response) { [{ "is_included" => true, "is_singleton" => false, "quantity" => 1, "record_id" => 123_456, "type_id" => 587 }] }
+  describe '#get_corporation_contract_items' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'is_included' => true, 'is_singleton' => false, 'quantity' => 1, 'record_id' => 123_456, 'type_id' => 587 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_contract_items(contract_id: "1234567890", corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_contract_items(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_contract_items(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_contract_items(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_corporation_contract_items(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_contract_items(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_contract_items(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-
-    context "when the response is 520" do
-      let(:response) { { "error" => "Error 520 message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/1234567890/items/").to_return(body: response.to_json, status: 520, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::EveServerError error" do
-        expect { client.get_corporation_contract_items(contract_id: "1234567890", corporation_id: "1234567890") }.to raise_error(ESI::Errors::EveServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_contract_items(contract_id: '1234567890', corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_contracts" do
-    context "when the response is 200" do
-      let(:response) { [{ "acceptor_id" => 0, "assignee_id" => 0, "availability" => "public", "buyout" => 10_000_000_000.01, "contract_id" => 1, "date_expired" => "2017-06-13T13:12:32Z", "date_issued" => "2017-06-06T13:12:32Z", "days_to_complete" => 0, "end_location_id" => 60_014_719, "for_corporation" => true, "issuer_corporation_id" => 456, "issuer_id" => 123, "price" => 1_000_000.01, "reward" => 0.01, "start_location_id" => 60_014_719, "status" => "outstanding", "type" => "auction", "volume" => 0.01 }] }
+  describe '#get_corporation_contracts' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'acceptor_id' => 0, 'assignee_id' => 0, 'availability' => 'public', 'buyout' => 10_000_000_000.01, 'contract_id' => 1, 'date_expired' => '2017-06-13T13:12:32Z', 'date_issued' => '2017-06-06T13:12:32Z', 'days_to_complete' => 0, 'end_location_id' => 60_014_719, 'for_corporation' => true, 'issuer_corporation_id' => 456, 'issuer_id' => 123, 'price' => 1_000_000.01, 'reward' => 0.01, 'start_location_id' => 60_014_719, 'status' => 'outstanding', 'type' => 'auction', 'volume' => 0.01 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/contracts/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_contracts(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_contracts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_contracts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_contracts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_contracts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/contracts/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_contracts(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_contracts(corporation_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/corporation_spec.rb
+++ b/spec/lib/esi/client/corporation_spec.rb
@@ -1,1560 +1,312 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Corporation, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_corporation" do
-    context "when the response is 200" do
-      let(:response) { { "alliance_id" => 434_243_723, "ceo_id" => 180_548_812, "creator_id" => 180_548_812, "date_founded" => "2004-11-28T16:42:51Z", "description" => "This is a corporation description, it's basically just a string", "member_count" => 656, "name" => "C C P", "tax_rate" => 0.256, "ticker" => "-CCP-", "url" => "http://www.eveonline.com" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_corporation(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_corporation' do
+    context 'when the response is 200' do
+      let(:response) { { 'alliance_id' => 434_243_723, 'ceo_id' => 180_548_812, 'creator_id' => 180_548_812, 'date_founded' => '2004-11-28T16:42:51Z', 'description' => "This is a corporation description, it's basically just a string", 'member_count' => 656, 'name' => 'C C P', 'tax_rate' => 0.256, 'ticker' => '-CCP-', 'url' => 'http://www.eveonline.com' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_corporation(corporation_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_alliancehistory" do
-    context "when the response is 200" do
-      let(:response) { [{ "alliance_id" => 99_000_006, "is_deleted" => true, "record_id" => 23, "start_date" => "2016-10-25T14:46:00Z" }, { "record_id" => 1, "start_date" => "2015-07-06T20:56:00Z" }] }
+  describe '#get_corporation_alliancehistory' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'alliance_id' => 99_000_006, 'is_deleted' => true, 'record_id' => 23, 'start_date' => '2016-10-25T14:46:00Z' }, { 'record_id' => 1, 'start_date' => '2015-07-06T20:56:00Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/alliancehistory/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/alliancehistory/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_alliancehistory(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/alliancehistory/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_alliancehistory(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/alliancehistory/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_alliancehistory(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/alliancehistory/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_alliancehistory(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_alliancehistory(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_blueprints" do
-    context "when the response is 200" do
-      let(:response) { [{ "item_id" => 1_000_000_010_495, "location_flag" => "CorpSAG1", "location_id" => 60_014_719, "material_efficiency" => 0, "quantity" => 1, "runs" => -1, "time_efficiency" => 0, "type_id" => 691 }] }
+  describe '#get_corporation_blueprints' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'item_id' => 1_000_000_010_495, 'location_flag' => 'CorpSAG1', 'location_id' => 60_014_719, 'material_efficiency' => 0, 'quantity' => 1, 'runs' => -1, 'time_efficiency' => 0, 'type_id' => 691 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/blueprints/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/blueprints/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_blueprints(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/blueprints/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_blueprints(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/blueprints/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_blueprints(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/blueprints/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_blueprints(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/blueprints/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_blueprints(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/blueprints/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_blueprints(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_blueprints(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_container_logs" do
-    context "when the response is 200" do
-      let(:response) { [{ "action" => "set_password", "character_id" => 2_112_625_428, "container_id" => 1_000_000_012_279, "container_type_id" => 17_365, "location_flag" => "CorpSAG1", "location_id" => 1_000_000_012_278, "logged_at" => "2017-10-10T14:00:00Z", "password_type" => "general" }, { "action" => "lock", "character_id" => 2_112_625_428, "container_id" => 1_000_000_012_279, "container_type_id" => 17_365, "location_flag" => "CorpSAG1", "location_id" => 1_000_000_012_278, "logged_at" => "2017-10-11T12:04:33Z", "quantity" => 30, "type_id" => 1230 }, { "action" => "configure", "character_id" => 2_112_625_428, "container_id" => 1_000_000_012_279, "container_type_id" => 17_365, "location_flag" => "CorpSAG2", "location_id" => 1_000_000_012_278, "logged_at" => "2017-10-11T12:06:29Z", "new_config_bitmask" => 31, "old_config_bitmask" => 23 }] }
+  describe '#get_corporation_container_logs' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'action' => 'set_password', 'character_id' => 2_112_625_428, 'container_id' => 1_000_000_012_279, 'container_type_id' => 17_365, 'location_flag' => 'CorpSAG1', 'location_id' => 1_000_000_012_278, 'logged_at' => '2017-10-10T14:00:00Z', 'password_type' => 'general' }, { 'action' => 'lock', 'character_id' => 2_112_625_428, 'container_id' => 1_000_000_012_279, 'container_type_id' => 17_365, 'location_flag' => 'CorpSAG1', 'location_id' => 1_000_000_012_278, 'logged_at' => '2017-10-11T12:04:33Z', 'quantity' => 30, 'type_id' => 1230 }, { 'action' => 'configure', 'character_id' => 2_112_625_428, 'container_id' => 1_000_000_012_279, 'container_type_id' => 17_365, 'location_flag' => 'CorpSAG2', 'location_id' => 1_000_000_012_278, 'logged_at' => '2017-10-11T12:06:29Z', 'new_config_bitmask' => 31, 'old_config_bitmask' => 23 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/containers/logs/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/containers/logs/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_container_logs(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/containers/logs/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_container_logs(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/containers/logs/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_container_logs(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/containers/logs/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_container_logs(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/containers/logs/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_container_logs(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/containers/logs/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_container_logs(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_container_logs(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_divisions" do
-    context "when the response is 200" do
-      let(:response) { { "hangar" => [{ "division" => 1, "name" => "Awesome Hangar 1" }], "wallet" => [{ "division" => 1, "name" => "Rich Wallet 1" }] } }
+  describe '#get_corporation_divisions' do
+    context 'when the response is 200' do
+      let(:response) { { 'hangar' => [{ 'division' => 1, 'name' => 'Awesome Hangar 1' }], 'wallet' => [{ 'division' => 1, 'name' => 'Rich Wallet 1' }] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/divisions/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/divisions/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_divisions(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/divisions/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_divisions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/divisions/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_divisions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/divisions/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_divisions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/divisions/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_divisions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/divisions/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_divisions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_divisions(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_facilities" do
-    context "when the response is 200" do
-      let(:response) { [{ "facility_id" => 123, "system_id" => 45_678, "type_id" => 2502 }] }
+  describe '#get_corporation_facilities' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'facility_id' => 123, 'system_id' => 45_678, 'type_id' => 2502 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/facilities/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/facilities/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_facilities(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/facilities/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_facilities(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/facilities/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_facilities(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/facilities/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_facilities(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/facilities/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_facilities(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/facilities/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_facilities(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_facilities(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_icons" do
-    context "when the response is 200" do
-      let(:response) { { "px128x128" => "https://images.evetech.net/corporations/1000010/logo?tenant=tranquility&size=128", "px256x256" => "https://images.evetech.net/corporations/1000010/logo?tenant=tranquility&size=256", "px64x64" => "https://images.evetech.net/corporations/1000010/logo?tenant=tranquility&size=64" } }
+  describe '#get_corporation_icons' do
+    context 'when the response is 200' do
+      let(:response) { { 'px128x128' => 'https://images.evetech.net/corporations/1000010/logo?tenant=tranquility&size=128', 'px256x256' => 'https://images.evetech.net/corporations/1000010/logo?tenant=tranquility&size=256', 'px64x64' => 'https://images.evetech.net/corporations/1000010/logo?tenant=tranquility&size=64' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/icons/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/icons/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_icons(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/icons/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_icons(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "No image server for this datasource" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/icons/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_corporation_icons(corporation_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/icons/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_icons(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/icons/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_icons(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_icons(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_medals" do
-    context "when the response is 200" do
-      let(:response) { [{ "created_at" => "2017-10-10T14:00:00Z", "creator_id" => 46_578, "description" => "An Awesome Medal", "medal_id" => 123, "title" => "Awesome Medal" }] }
+  describe '#get_corporation_medals' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'created_at' => '2017-10-10T14:00:00Z', 'creator_id' => 46_578, 'description' => 'An Awesome Medal', 'medal_id' => 123, 'title' => 'Awesome Medal' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/medals/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_medals(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_medals(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_medals(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_medals(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_medals(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_medals(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_medals(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_medals_issued" do
-    context "when the response is 200" do
-      let(:response) { [{ "character_id" => 45_678, "issued_at" => "2017-10-10T14:00:00Z", "issuer_id" => 67_890, "medal_id" => 123, "reason" => "Awesome Reason", "status" => "private" }] }
+  describe '#get_corporation_medals_issued' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'character_id' => 45_678, 'issued_at' => '2017-10-10T14:00:00Z', 'issuer_id' => 67_890, 'medal_id' => 123, 'reason' => 'Awesome Reason', 'status' => 'private' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/issued/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/medals/issued/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_medals_issued(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/issued/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_medals_issued(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/issued/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_medals_issued(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/issued/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_medals_issued(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/issued/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_medals_issued(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/medals/issued/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_medals_issued(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_medals_issued(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_member_titles" do
-    context "when the response is 200" do
-      let(:response) { [{ "character_id" => 12_345, "titles" => [] }] }
+  describe '#get_corporation_member_titles' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'character_id' => 12_345, 'titles' => [] }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/titles/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/members/titles/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_member_titles(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/titles/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_member_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/titles/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_member_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/titles/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_member_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/titles/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_member_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/titles/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_member_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_member_titles(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_members" do
-    context "when the response is 200" do
+  describe '#get_corporation_members' do
+    context 'when the response is 200' do
       let(:response) { [90_000_001, 90_000_002] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/members/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_members(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_members(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_members(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_members(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_members(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_members(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_members(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_members_limit" do
-    context "when the response is 200" do
+  describe '#get_corporation_members_limit' do
+    context 'when the response is 200' do
       let(:response) { 40 }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/limit/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/members/limit/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_members_limit(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/limit/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_members_limit(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/limit/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_members_limit(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/limit/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_members_limit(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/limit/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_members_limit(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/members/limit/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_members_limit(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_members_limit(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_membertracking" do
-    context "when the response is 200" do
-      let(:response) { [{ "character_id" => 2_112_000_001, "location_id" => 30_003_657, "logoff_date" => "2017-08-03T14:31:16Z", "logon_date" => "2017-08-03T14:22:03Z", "ship_type_id" => 22_464, "start_date" => "2017-07-10T14:46:00Z" }, { "character_id" => 2_112_000_002, "location_id" => 30_003_657, "logoff_date" => "2017-07-25T11:07:40Z", "logon_date" => "2017-07-25T10:54:00Z", "ship_type_id" => 670, "start_date" => "2017-07-10T14:50:00Z" }] }
+  describe '#get_corporation_membertracking' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'character_id' => 2_112_000_001, 'location_id' => 30_003_657, 'logoff_date' => '2017-08-03T14:31:16Z', 'logon_date' => '2017-08-03T14:22:03Z', 'ship_type_id' => 22_464, 'start_date' => '2017-07-10T14:46:00Z' }, { 'character_id' => 2_112_000_002, 'location_id' => 30_003_657, 'logoff_date' => '2017-07-25T11:07:40Z', 'logon_date' => '2017-07-25T10:54:00Z', 'ship_type_id' => 670, 'start_date' => '2017-07-10T14:50:00Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/membertracking/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/membertracking/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_membertracking(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/membertracking/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_membertracking(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/membertracking/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_membertracking(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/membertracking/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_membertracking(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/membertracking/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_membertracking(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/membertracking/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_membertracking(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_membertracking(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_npccorps" do
-    context "when the response is 200" do
+  describe '#get_corporation_npccorps' do
+    context 'when the response is 200' do
       let(:response) { [1_000_001, 1_000_002, 1_000_003] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/npccorps/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/npccorps/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_corporation_npccorps).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/npccorps/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_npccorps }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_corporation_roles' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'character_id' => 1_000_171, 'roles' => %w[Director Station_Manager] }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/npccorps/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/roles/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_npccorps }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/npccorps/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_npccorps }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_roles(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_roles" do
-    context "when the response is 200" do
-      let(:response) { [{ "character_id" => 1_000_171, "roles" => %w[Director Station_Manager] }] }
+  describe '#get_corporation_roles_history' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'changed_at' => '2016-10-25T14:46:00Z', 'character_id' => 12_345, 'issuer_id' => 45_678, 'new_roles' => ['Station_Manager'], 'old_roles' => ['Diplomat'], 'role_type' => 'roles' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/roles/history/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_roles(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_roles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_roles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_roles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_roles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_roles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_roles_history(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_roles_history" do
-    context "when the response is 200" do
-      let(:response) { [{ "changed_at" => "2016-10-25T14:46:00Z", "character_id" => 12_345, "issuer_id" => 45_678, "new_roles" => ["Station_Manager"], "old_roles" => ["Diplomat"], "role_type" => "roles" }] }
+  describe '#get_corporation_shareholders' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'share_count' => 580, 'shareholder_id' => 98_000_001, 'shareholder_type' => 'corporation' }, { 'share_count' => 20, 'shareholder_id' => 2_112_000_003, 'shareholder_type' => 'character' }, { 'share_count' => 300, 'shareholder_id' => 2_112_000_004, 'shareholder_type' => 'character' }, { 'share_count' => 100, 'shareholder_id' => 2_112_000_001, 'shareholder_type' => 'character' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/history/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/shareholders/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_roles_history(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/history/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_roles_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/history/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_roles_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/history/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_roles_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/history/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_roles_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/roles/history/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_roles_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_shareholders(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_shareholders" do
-    context "when the response is 200" do
-      let(:response) { [{ "share_count" => 580, "shareholder_id" => 98_000_001, "shareholder_type" => "corporation" }, { "share_count" => 20, "shareholder_id" => 2_112_000_003, "shareholder_type" => "character" }, { "share_count" => 300, "shareholder_id" => 2_112_000_004, "shareholder_type" => "character" }, { "share_count" => 100, "shareholder_id" => 2_112_000_001, "shareholder_type" => "character" }] }
+  describe '#get_corporation_standings' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'from_id' => 3_009_841, 'from_type' => 'agent', 'standing' => 0.1 }, { 'from_id' => 1_000_061, 'from_type' => 'npc_corp', 'standing' => 0 }, { 'from_id' => 500_003, 'from_type' => 'faction', 'standing' => -1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/shareholders/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/standings/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_shareholders(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/shareholders/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_shareholders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/shareholders/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_shareholders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/shareholders/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_shareholders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/shareholders/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_shareholders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/shareholders/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_shareholders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_standings(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_standings" do
-    context "when the response is 200" do
-      let(:response) { [{ "from_id" => 3_009_841, "from_type" => "agent", "standing" => 0.1 }, { "from_id" => 1_000_061, "from_type" => "npc_corp", "standing" => 0 }, { "from_id" => 500_003, "from_type" => "faction", "standing" => -1 }] }
+  describe '#get_corporation_starbase' do
+    context 'when the response is 200' do
+      let(:response) { { 'allow_alliance_members' => false, 'allow_corporation_members' => true, 'anchor' => 'config_starbase_equipment_role', 'attack_if_at_war' => true, 'attack_if_other_security_status_dropping' => false, 'fuel_bay_take' => 'config_starbase_equipment_role', 'fuel_bay_view' => 'config_starbase_equipment_role', 'offline' => 'config_starbase_equipment_role', 'online' => 'config_starbase_equipment_role', 'unanchor' => 'config_starbase_equipment_role', 'use_alliance_standings' => false } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/standings/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/starbases/1234567890/').with(query: { system_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_standings(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/standings/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_standings(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/standings/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_standings(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/standings/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_standings(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/standings/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_standings(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/standings/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_standings(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_starbase(corporation_id: '1234567890', starbase_id: '1234567890', system_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_starbase" do
-    context "when the response is 200" do
-      let(:response) { { "allow_alliance_members" => false, "allow_corporation_members" => true, "anchor" => "config_starbase_equipment_role", "attack_if_at_war" => true, "attack_if_other_security_status_dropping" => false, "fuel_bay_take" => "config_starbase_equipment_role", "fuel_bay_view" => "config_starbase_equipment_role", "offline" => "config_starbase_equipment_role", "online" => "config_starbase_equipment_role", "unanchor" => "config_starbase_equipment_role", "use_alliance_standings" => false } }
+  describe '#get_corporation_starbases' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'starbase_id' => 12_345, 'system_id' => 123_456, 'type_id' => 456 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/1234567890/").with(query: { system_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/starbases/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_starbase(corporation_id: "1234567890", starbase_id: "1234567890", system_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/1234567890/").with(query: { system_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_starbase(corporation_id: "1234567890", starbase_id: "1234567890", system_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/1234567890/").with(query: { system_id: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_starbase(corporation_id: "1234567890", starbase_id: "1234567890", system_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/1234567890/").with(query: { system_id: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_starbase(corporation_id: "1234567890", starbase_id: "1234567890", system_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/1234567890/").with(query: { system_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_starbase(corporation_id: "1234567890", starbase_id: "1234567890", system_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/1234567890/").with(query: { system_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_starbase(corporation_id: "1234567890", starbase_id: "1234567890", system_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_starbases(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_starbases" do
-    context "when the response is 200" do
-      let(:response) { [{ "starbase_id" => 12_345, "system_id" => 123_456, "type_id" => 456 }] }
+  describe '#get_corporation_structures' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'corporation_id' => 667_531_913, 'name' => 'example name', 'profile_id' => 11_237, 'reinforce_hour' => 22, 'state' => 'shield_vulnerable', 'structure_id' => 1_021_975_535_893, 'system_id' => 30_004_763, 'type_id' => 35_833 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/structures/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_starbases(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_starbases(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_starbases(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_starbases(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_starbases(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/starbases/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_starbases(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_structures(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_structures" do
-    context "when the response is 200" do
-      let(:response) { [{ "corporation_id" => 667_531_913, "name" => "example name", "profile_id" => 11_237, "reinforce_hour" => 22, "state" => "shield_vulnerable", "structure_id" => 1_021_975_535_893, "system_id" => 30_004_763, "type_id" => 35_833 }] }
+  describe '#get_corporation_titles' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'name' => 'Awesome Title', 'roles' => %w[Hangar_Take_6 Hangar_Query_2], 'title_id' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/structures/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/titles/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_structures(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/structures/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_structures(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/structures/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_structures(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/structures/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_structures(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/structures/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_structures(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/structures/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_structures(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_corporation_titles" do
-    context "when the response is 200" do
-      let(:response) { [{ "name" => "Awesome Title", "roles" => %w[Hangar_Take_6 Hangar_Query_2], "title_id" => 1 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/titles/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_corporation_titles(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/titles/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/titles/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/titles/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/titles/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/titles/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_titles(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_titles(corporation_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/dogma_spec.rb
+++ b/spec/lib/esi/client/dogma_spec.rb
@@ -1,290 +1,74 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Dogma, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_dogma_attribute" do
-    context "when the response is 200" do
-      let(:response) { { "attribute_id" => 20, "default_value" => 1, "description" => "Factor by which topspeed increases.", "display_name" => "Maximum Velocity Bonus", "high_is_good" => true, "icon_id" => 1389, "name" => "speedFactor", "published" => true, "unit_id" => 124 } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_dogma_attribute(attribute_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_dogma_attribute' do
+    context 'when the response is 200' do
+      let(:response) { { 'attribute_id' => 20, 'default_value' => 1, 'description' => 'Factor by which topspeed increases.', 'display_name' => 'Maximum Velocity Bonus', 'high_is_good' => true, 'icon_id' => 1389, 'name' => 'speedFactor', 'published' => true, 'unit_id' => 124 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/dogma/attributes/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_dogma_attribute(attribute_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_dogma_attribute(attribute_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_dogma_attribute(attribute_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_dogma_attribute(attribute_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_dogma_attribute(attribute_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_dogma_attributes" do
-    context "when the response is 200" do
+  describe '#get_dogma_attributes' do
+    context 'when the response is 200' do
       let(:response) { [1, 2, 3] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/dogma/attributes/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_dogma_attributes).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_dogma_attributes }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_dogma_dynamic_items_type_item' do
+    context 'when the response is 200' do
+      let(:response) { { 'created_by' => 2_112_625_428, 'dogma_attributes' => [{ 'attribute_id' => 9, 'value' => 350 }], 'dogma_effects' => [{ 'effect_id' => 508, 'is_default' => false }], 'mutator_type_id' => 47_845, 'source_type_id' => 33_103 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/dogma/dynamic/items/1234567890/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_dogma_attributes }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/attributes/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_dogma_attributes }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_dogma_dynamic_items_type_item(item_id: '1234567890', type_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_dogma_dynamic_items_type_item" do
-    context "when the response is 200" do
-      let(:response) { { "created_by" => 2_112_625_428, "dogma_attributes" => [{ "attribute_id" => 9, "value" => 350 }], "dogma_effects" => [{ "effect_id" => 508, "is_default" => false }], "mutator_type_id" => 47_845, "source_type_id" => 33_103 } }
+  describe '#get_dogma_effect' do
+    context 'when the response is 200' do
+      let(:response) { { 'description' => 'Requires a high power slot.', 'display_name' => 'High power', 'effect_category' => 0, 'effect_id' => 12, 'icon_id' => 293, 'name' => 'hiPower', 'post_expression' => 131, 'pre_expression' => 131, 'published' => true } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/dynamic/items/1234567890/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/dogma/effects/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_dogma_dynamic_items_type_item(item_id: "1234567890", type_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/dynamic/items/1234567890/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_dogma_dynamic_items_type_item(item_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/dynamic/items/1234567890/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_dogma_dynamic_items_type_item(item_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/dynamic/items/1234567890/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_dogma_dynamic_items_type_item(item_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/dynamic/items/1234567890/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_dogma_dynamic_items_type_item(item_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_dogma_effect(effect_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_dogma_effect" do
-    context "when the response is 200" do
-      let(:response) { { "description" => "Requires a high power slot.", "display_name" => "High power", "effect_category" => 0, "effect_id" => 12, "icon_id" => 293, "name" => "hiPower", "post_expression" => 131, "pre_expression" => 131, "published" => true } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_dogma_effect(effect_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_dogma_effect(effect_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_dogma_effect(effect_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_dogma_effect(effect_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_dogma_effect(effect_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_dogma_effects" do
-    context "when the response is 200" do
+  describe '#get_dogma_effects' do
+    context 'when the response is 200' do
       let(:response) { [1, 2, 3] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/dogma/effects/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_dogma_effects).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_dogma_effects }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_dogma_effects }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/dogma/effects/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_dogma_effects }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/faction_warfare_spec.rb
+++ b/spec/lib/esi/client/faction_warfare_spec.rb
@@ -1,452 +1,116 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::FactionWarfare, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_fw_stats" do
-    context "when the response is 200" do
-      let(:response) { { "enlisted_on" => "2017-10-17T00:00:00Z", "faction_id" => 500_001, "kills" => { "last_week" => 893, "total" => 684_350, "yesterday" => 136 }, "victory_points" => { "last_week" => 102_640, "total" => 52_658_260, "yesterday" => 15_980 } } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fw/stats/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_fw_stats(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_fw_stats' do
+    context 'when the response is 200' do
+      let(:response) { { 'enlisted_on' => '2017-10-17T00:00:00Z', 'faction_id' => 500_001, 'kills' => { 'last_week' => 893, 'total' => 684_350, 'yesterday' => 136 }, 'victory_points' => { 'last_week' => 102_640, 'total' => 52_658_260, 'yesterday' => 15_980 } } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fw/stats/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/fw/stats/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_fw_stats(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fw/stats/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_fw_stats(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fw/stats/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_fw_stats(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fw/stats/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_fw_stats(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fw/stats/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_fw_stats(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_fw_stats(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_fw_stats" do
-    context "when the response is 200" do
-      let(:response) { { "enlisted_on" => "2017-10-17T00:00:00Z", "faction_id" => 500_001, "kills" => { "last_week" => 893, "total" => 684_350, "yesterday" => 136 }, "pilots" => 28_863, "victory_points" => { "last_week" => 102_640, "total" => 52_658_260, "yesterday" => 15_980 } } }
+  describe '#get_corporation_fw_stats' do
+    context 'when the response is 200' do
+      let(:response) { { 'enlisted_on' => '2017-10-17T00:00:00Z', 'faction_id' => 500_001, 'kills' => { 'last_week' => 893, 'total' => 684_350, 'yesterday' => 136 }, 'pilots' => 28_863, 'victory_points' => { 'last_week' => 102_640, 'total' => 52_658_260, 'yesterday' => 15_980 } } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/fw/stats/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/fw/stats/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_fw_stats(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/fw/stats/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_fw_stats(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/fw/stats/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_fw_stats(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/fw/stats/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_fw_stats(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/fw/stats/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_fw_stats(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/fw/stats/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_fw_stats(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_fw_stats(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_fw_leaderboard_characters" do
-    context "when the response is 200" do
-      let(:response) { { "kills" => { "active_total" => [{ "amount" => 10_000, "character_id" => 2_112_625_428 }, { "amount" => 8500, "character_id" => 95_465_499 }], "last_week" => [{ "amount" => 100, "character_id" => 2_112_625_428 }, { "amount" => 70, "character_id" => 95_465_499 }], "yesterday" => [{ "amount" => 34, "character_id" => 2_112_625_428 }, { "amount" => 20, "character_id" => 95_465_499 }] }, "victory_points" => { "active_total" => [{ "amount" => 1_239_158, "character_id" => 2_112_625_428 }, { "amount" => 1_139_029, "character_id" => 95_465_499 }], "last_week" => [{ "amount" => 2660, "character_id" => 2_112_625_428 }, { "amount" => 2000, "character_id" => 95_465_499 }], "yesterday" => [{ "amount" => 620, "character_id" => 2_112_625_428 }, { "amount" => 550, "character_id" => 95_465_499 }] } } }
+  describe '#get_fw_leaderboard_characters' do
+    context 'when the response is 200' do
+      let(:response) { { 'kills' => { 'active_total' => [{ 'amount' => 10_000, 'character_id' => 2_112_625_428 }, { 'amount' => 8500, 'character_id' => 95_465_499 }], 'last_week' => [{ 'amount' => 100, 'character_id' => 2_112_625_428 }, { 'amount' => 70, 'character_id' => 95_465_499 }], 'yesterday' => [{ 'amount' => 34, 'character_id' => 2_112_625_428 }, { 'amount' => 20, 'character_id' => 95_465_499 }] }, 'victory_points' => { 'active_total' => [{ 'amount' => 1_239_158, 'character_id' => 2_112_625_428 }, { 'amount' => 1_139_029, 'character_id' => 95_465_499 }], 'last_week' => [{ 'amount' => 2660, 'character_id' => 2_112_625_428 }, { 'amount' => 2000, 'character_id' => 95_465_499 }], 'yesterday' => [{ 'amount' => 620, 'character_id' => 2_112_625_428 }, { 'amount' => 550, 'character_id' => 95_465_499 }] } } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/characters/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fw/leaderboards/characters/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_fw_leaderboard_characters).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/characters/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fw_leaderboard_characters }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/characters/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fw_leaderboard_characters }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/characters/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fw_leaderboard_characters }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_fw_leaderboard_corporations" do
-    context "when the response is 200" do
-      let(:response) { { "kills" => { "active_total" => [{ "amount" => 81_692, "corporation_id" => 1_000_180 }, { "amount" => 76_793, "corporation_id" => 1_000_182 }], "last_week" => [{ "amount" => 290, "corporation_id" => 1_000_180 }, { "amount" => 169, "corporation_id" => 1_000_182 }], "yesterday" => [{ "amount" => 51, "corporation_id" => 1_000_180 }, { "amount" => 39, "corporation_id" => 1_000_182 }] }, "victory_points" => { "active_total" => [{ "amount" => 18_640_927, "corporation_id" => 1_000_180 }, { "amount" => 18_078_265, "corporation_id" => 1_000_181 }], "last_week" => [{ "amount" => 91_980, "corporation_id" => 1_000_180 }, { "amount" => 58_920, "corporation_id" => 1_000_181 }], "yesterday" => [{ "amount" => 12_600, "corporation_id" => 1_000_180 }, { "amount" => 8240, "corporation_id" => 1_000_181 }] } } }
+  describe '#get_fw_leaderboard_corporations' do
+    context 'when the response is 200' do
+      let(:response) { { 'kills' => { 'active_total' => [{ 'amount' => 81_692, 'corporation_id' => 1_000_180 }, { 'amount' => 76_793, 'corporation_id' => 1_000_182 }], 'last_week' => [{ 'amount' => 290, 'corporation_id' => 1_000_180 }, { 'amount' => 169, 'corporation_id' => 1_000_182 }], 'yesterday' => [{ 'amount' => 51, 'corporation_id' => 1_000_180 }, { 'amount' => 39, 'corporation_id' => 1_000_182 }] }, 'victory_points' => { 'active_total' => [{ 'amount' => 18_640_927, 'corporation_id' => 1_000_180 }, { 'amount' => 18_078_265, 'corporation_id' => 1_000_181 }], 'last_week' => [{ 'amount' => 91_980, 'corporation_id' => 1_000_180 }, { 'amount' => 58_920, 'corporation_id' => 1_000_181 }], 'yesterday' => [{ 'amount' => 12_600, 'corporation_id' => 1_000_180 }, { 'amount' => 8240, 'corporation_id' => 1_000_181 }] } } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/corporations/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fw/leaderboards/corporations/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_fw_leaderboard_corporations).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/corporations/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fw_leaderboard_corporations }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/corporations/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fw_leaderboard_corporations }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/corporations/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fw_leaderboard_corporations }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_fw_leaderboards" do
-    context "when the response is 200" do
-      let(:response) { { "kills" => { "active_total" => [{ "amount" => 832_273, "faction_id" => 500_004 }, { "amount" => 687_915, "faction_id" => 500_001 }], "last_week" => [{ "amount" => 730, "faction_id" => 500_001 }, { "amount" => 671, "faction_id" => 500_004 }], "yesterday" => [{ "amount" => 100, "faction_id" => 500_001 }, { "amount" => 50, "faction_id" => 500_004 }] }, "victory_points" => { "active_total" => [{ "amount" => 53_130_500, "faction_id" => 500_001 }, { "amount" => 50_964_263, "faction_id" => 500_004 }], "last_week" => [{ "amount" => 97_360, "faction_id" => 500_001 }, { "amount" => 84_980, "faction_id" => 500_004 }], "yesterday" => [{ "amount" => 5000, "faction_id" => 500_002 }, { "amount" => 3500, "faction_id" => 500_003 }] } } }
+  describe '#get_fw_leaderboards' do
+    context 'when the response is 200' do
+      let(:response) { { 'kills' => { 'active_total' => [{ 'amount' => 832_273, 'faction_id' => 500_004 }, { 'amount' => 687_915, 'faction_id' => 500_001 }], 'last_week' => [{ 'amount' => 730, 'faction_id' => 500_001 }, { 'amount' => 671, 'faction_id' => 500_004 }], 'yesterday' => [{ 'amount' => 100, 'faction_id' => 500_001 }, { 'amount' => 50, 'faction_id' => 500_004 }] }, 'victory_points' => { 'active_total' => [{ 'amount' => 53_130_500, 'faction_id' => 500_001 }, { 'amount' => 50_964_263, 'faction_id' => 500_004 }], 'last_week' => [{ 'amount' => 97_360, 'faction_id' => 500_001 }, { 'amount' => 84_980, 'faction_id' => 500_004 }], 'yesterday' => [{ 'amount' => 5000, 'faction_id' => 500_002 }, { 'amount' => 3500, 'faction_id' => 500_003 }] } } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fw/leaderboards/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_fw_leaderboards).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fw_leaderboards }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fw_leaderboards }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/leaderboards/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fw_leaderboards }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_fw_stats" do
-    context "when the response is 200" do
-      let(:response) { [{ "faction_id" => 500_001, "kills" => { "last_week" => 893, "total" => 684_350, "yesterday" => 136 }, "pilots" => 28_863, "systems_controlled" => 20, "victory_points" => { "last_week" => 102_640, "total" => 52_658_260, "yesterday" => 15_980 } }] }
+  describe '#get_fw_stats' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'faction_id' => 500_001, 'kills' => { 'last_week' => 893, 'total' => 684_350, 'yesterday' => 136 }, 'pilots' => 28_863, 'systems_controlled' => 20, 'victory_points' => { 'last_week' => 102_640, 'total' => 52_658_260, 'yesterday' => 15_980 } }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/stats/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fw/stats/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_fw_stats).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/stats/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fw_stats }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/stats/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fw_stats }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/stats/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fw_stats }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_fw_systems" do
-    context "when the response is 200" do
-      let(:response) { [{ "contested" => "uncontested", "occupier_faction_id" => 500_001, "owner_faction_id" => 500_001, "solar_system_id" => 30_002_096, "victory_points" => 60, "victory_points_threshold" => 3000 }] }
+  describe '#get_fw_systems' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'contested' => 'uncontested', 'occupier_faction_id' => 500_001, 'owner_faction_id' => 500_001, 'solar_system_id' => 30_002_096, 'victory_points' => 60, 'victory_points_threshold' => 3000 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/systems/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fw/systems/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_fw_systems).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/systems/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fw_systems }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/systems/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fw_systems }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/systems/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fw_systems }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_fw_wars" do
-    context "when the response is 200" do
-      let(:response) { [{ "against_id" => 500_002, "faction_id" => 500_001 }] }
+  describe '#get_fw_wars' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'against_id' => 500_002, 'faction_id' => 500_001 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/wars/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fw/wars/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_fw_wars).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/wars/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fw_wars }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/wars/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fw_wars }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fw/wars/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fw_wars }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/fittings_spec.rb
+++ b/spec/lib/esi/client/fittings_spec.rb
@@ -1,226 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Fitting, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#delete_character_fitting" do
-    context "when the response is 204" do
+  describe '#delete_character_fitting' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/fittings/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:delete, 'https://esi.evetech.net/latest/characters/1234567890/fittings/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.delete_character_fitting(character_id: "1234567890", fitting_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/fittings/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.delete_character_fitting(character_id: "1234567890", fitting_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/fittings/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.delete_character_fitting(character_id: "1234567890", fitting_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/fittings/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.delete_character_fitting(character_id: "1234567890", fitting_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/fittings/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.delete_character_fitting(character_id: "1234567890", fitting_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/fittings/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.delete_character_fitting(character_id: "1234567890", fitting_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.delete_character_fitting(character_id: '1234567890', fitting_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_fittings" do
-    context "when the response is 200" do
-      let(:response) { [{ "description" => "Awesome Vindi fitting", "fitting_id" => 1, "items" => [{ "flag" => "Cargo", "quantity" => 1, "type_id" => 1234 }], "name" => "Best Vindicator", "ship_type_id" => 123 }] }
+  describe '#get_character_fittings' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'description' => 'Awesome Vindi fitting', 'fitting_id' => 1, 'items' => [{ 'flag' => 'Cargo', 'quantity' => 1, 'type_id' => 1234 }], 'name' => 'Best Vindicator', 'ship_type_id' => 123 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/fittings/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_fittings(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_fittings(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_fittings(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_fittings(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_fittings(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_fittings(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_fittings(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_character_fittings" do
-    context "when the response is 201" do
-      let(:response) { { "fitting_id" => 2 } }
+  describe '#post_character_fittings' do
+    context 'when the response is 201' do
+      let(:response) { { 'fitting_id' => 2 } }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/characters/1234567890/fittings/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_character_fittings(character_id: "1234567890", fitting: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_character_fittings(character_id: "1234567890", fitting: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_character_fittings(character_id: "1234567890", fitting: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_character_fittings(character_id: "1234567890", fitting: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_character_fittings(character_id: "1234567890", fitting: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/fittings/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_character_fittings(character_id: "1234567890", fitting: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_character_fittings(character_id: '1234567890', fitting: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/fleets_spec.rb
+++ b/spec/lib/esi/client/fleets_spec.rb
@@ -1,1232 +1,200 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Fleet, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#delete_fleet_member" do
-    context "when the response is 204" do
+  describe '#delete_fleet_member' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:delete, 'https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.delete_fleet_member(fleet_id: "1234567890", member_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.delete_fleet_member(fleet_id: "1234567890", member_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.delete_fleet_member(fleet_id: "1234567890", member_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.delete_fleet_member(fleet_id: "1234567890", member_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.delete_fleet_member(fleet_id: "1234567890", member_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.delete_fleet_member(fleet_id: "1234567890", member_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.delete_fleet_member(fleet_id: "1234567890", member_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.delete_fleet_member(fleet_id: '1234567890', member_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#delete_fleet_squad" do
-    context "when the response is 204" do
+  describe '#delete_fleet_squad' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:delete, 'https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.delete_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.delete_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.delete_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.delete_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.delete_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.delete_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.delete_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.delete_fleet_squad(fleet_id: '1234567890', squad_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#delete_fleet_wing" do
-    context "when the response is 204" do
+  describe '#delete_fleet_wing' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:delete, 'https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.delete_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.delete_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.delete_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.delete_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.delete_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.delete_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.delete_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.delete_fleet_wing(fleet_id: '1234567890', wing_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_fleet" do
-    context "when the response is 200" do
-      let(:response) { { "fleet_id" => 1_234_567_890, "role" => "fleet_commander", "squad_id" => -1, "wing_id" => -1 } }
+  describe '#get_character_fleet' do
+    context 'when the response is 200' do
+      let(:response) { { 'fleet_id' => 1_234_567_890, 'role' => 'fleet_commander', 'squad_id' => -1, 'wing_id' => -1 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fleet/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/fleet/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_fleet(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fleet/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_fleet(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fleet/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_fleet(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fleet/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_fleet(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fleet/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_fleet(character_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fleet/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_fleet(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/fleet/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_fleet(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_fleet(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_fleet" do
-    context "when the response is 200" do
-      let(:response) { { "is_free_move" => false, "is_registered" => false, "is_voice_enabled" => false, "motd" => "This is an <b>awesome</b> fleet!" } }
+  describe '#get_fleet' do
+    context 'when the response is 200' do
+      let(:response) { { 'is_free_move' => false, 'is_registered' => false, 'is_voice_enabled' => false, 'motd' => 'This is an <b>awesome</b> fleet!' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fleets/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_fleet(fleet_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fleet(fleet_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_fleet(fleet_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_fleet(fleet_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_fleet(fleet_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fleet(fleet_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fleet(fleet_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_fleet(fleet_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_fleet_members" do
-    context "when the response is 200" do
-      let(:response) { [{ "character_id" => 93_265_215, "join_time" => "2016-04-29T12:34:56Z", "role" => "squad_commander", "role_name" => "Squad Commander (Boss)", "ship_type_id" => 33_328, "solar_system_id" => 30_003_729, "squad_id" => 3_129_411_261_968, "station_id" => 61_000_180, "takes_fleet_warp" => true, "wing_id" => 2_073_711_261_968 }] }
+  describe '#get_fleet_members' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'character_id' => 93_265_215, 'join_time' => '2016-04-29T12:34:56Z', 'role' => 'squad_commander', 'role_name' => 'Squad Commander (Boss)', 'ship_type_id' => 33_328, 'solar_system_id' => 30_003_729, 'squad_id' => 3_129_411_261_968, 'station_id' => 61_000_180, 'takes_fleet_warp' => true, 'wing_id' => 2_073_711_261_968 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fleets/1234567890/members/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_fleet_members(fleet_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fleet_members(fleet_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_fleet_members(fleet_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_fleet_members(fleet_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_fleet_members(fleet_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fleet_members(fleet_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fleet_members(fleet_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_fleet_members(fleet_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_fleet_wings" do
-    context "when the response is 200" do
-      let(:response) { [{ "id" => 2_073_711_261_968, "name" => "Wing 1", "squads" => [{ "id" => 3_129_411_261_968, "name" => "Squad 1" }] }] }
+  describe '#get_fleet_wings' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'id' => 2_073_711_261_968, 'name' => 'Wing 1', 'squads' => [{ 'id' => 3_129_411_261_968, 'name' => 'Squad 1' }] }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/fleets/1234567890/wings/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_fleet_wings(fleet_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_fleet_wings(fleet_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_fleet_members" do
-    context "when the response is 204" do
+  describe '#post_fleet_members' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/fleets/1234567890/members/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_fleet_members(fleet_id: "1234567890", invitation: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_fleet_members(fleet_id: "1234567890", invitation: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_fleet_members(fleet_id: "1234567890", invitation: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_fleet_members(fleet_id: "1234567890", invitation: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.post_fleet_members(fleet_id: "1234567890", invitation: { "foo" => "bar" }) }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_fleet_members(fleet_id: "1234567890", invitation: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "missing wing_id" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.post_fleet_members(fleet_id: "1234567890", invitation: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/members/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_fleet_members(fleet_id: "1234567890", invitation: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_fleet_members(fleet_id: '1234567890', invitation: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end
 
-  describe "#post_fleet_wing_squads" do
-    context "when the response is 201" do
-      let(:response) { { "squad_id" => 123 } }
+  describe '#post_fleet_wing_squads' do
+    context 'when the response is 201' do
+      let(:response) { { 'squad_id' => 123 } }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/squads/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/squads/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_fleet_wing_squads(fleet_id: "1234567890", wing_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/squads/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_fleet_wing_squads(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/squads/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_fleet_wing_squads(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/squads/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_fleet_wing_squads(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/squads/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.post_fleet_wing_squads(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/squads/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_fleet_wing_squads(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/squads/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_fleet_wing_squads(fleet_id: "1234567890", wing_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_fleet_wing_squads(fleet_id: '1234567890', wing_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_fleet_wings" do
-    context "when the response is 201" do
-      let(:response) { { "wing_id" => 123 } }
+  describe '#post_fleet_wings' do
+    context 'when the response is 201' do
+      let(:response) { { 'wing_id' => 123 } }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/fleets/1234567890/wings/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_fleet_wings(fleet_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.post_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/fleets/1234567890/wings/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_fleet_wings(fleet_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_fleet_wings(fleet_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#put_fleet" do
-    context "when the response is 204" do
+  describe '#put_fleet' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:put, 'https://esi.evetech.net/latest/fleets/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.put_fleet(fleet_id: "1234567890", new_settings: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.put_fleet(fleet_id: "1234567890", new_settings: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.put_fleet(fleet_id: "1234567890", new_settings: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.put_fleet(fleet_id: "1234567890", new_settings: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.put_fleet(fleet_id: "1234567890", new_settings: { "foo" => "bar" }) }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.put_fleet(fleet_id: "1234567890", new_settings: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.put_fleet(fleet_id: "1234567890", new_settings: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.put_fleet(fleet_id: '1234567890', new_settings: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end
 
-  describe "#put_fleet_member" do
-    context "when the response is 204" do
+  describe '#put_fleet_member' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:put, 'https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.put_fleet_member(fleet_id: "1234567890", member_id: "1234567890", movement: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.put_fleet_member(fleet_id: "1234567890", member_id: "1234567890", movement: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.put_fleet_member(fleet_id: "1234567890", member_id: "1234567890", movement: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.put_fleet_member(fleet_id: "1234567890", member_id: "1234567890", movement: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.put_fleet_member(fleet_id: "1234567890", member_id: "1234567890", movement: { "foo" => "bar" }) }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.put_fleet_member(fleet_id: "1234567890", member_id: "1234567890", movement: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "missing wing_id" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.put_fleet_member(fleet_id: "1234567890", member_id: "1234567890", movement: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/members/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.put_fleet_member(fleet_id: "1234567890", member_id: "1234567890", movement: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.put_fleet_member(fleet_id: '1234567890', member_id: '1234567890', movement: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end
 
-  describe "#put_fleet_squad" do
-    context "when the response is 204" do
+  describe '#put_fleet_squad' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:put, 'https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.put_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890", naming: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.put_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.put_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.put_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.put_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.put_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/squads/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.put_fleet_squad(fleet_id: "1234567890", squad_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.put_fleet_squad(fleet_id: '1234567890', squad_id: '1234567890', naming: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end
 
-  describe "#put_fleet_wing" do
-    context "when the response is 204" do
+  describe '#put_fleet_wing' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:put, 'https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.put_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890", naming: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.put_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.put_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.put_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.put_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.put_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/fleets/1234567890/wings/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.put_fleet_wing(fleet_id: "1234567890", wing_id: "1234567890", naming: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.put_fleet_wing(fleet_id: '1234567890', wing_id: '1234567890', naming: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/incursions_spec.rb
+++ b/spec/lib/esi/client/incursions_spec.rb
@@ -1,54 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Incursion, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_incursions" do
-    context "when the response is 200" do
-      let(:response) { [{ "constellation_id" => 20_000_607, "faction_id" => 500_019, "has_boss" => true, "infested_solar_systems" => [30_004_148, 30_004_149, 30_004_150, 30_004_151, 30_004_152, 30_004_153, 30_004_154], "influence" => 0.9, "staging_solar_system_id" => 30_004_154, "state" => "mobilizing", "type" => "Incursion" }] }
+  describe '#get_incursions' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'constellation_id' => 20_000_607, 'faction_id' => 500_019, 'has_boss' => true, 'infested_solar_systems' => [30_004_148, 30_004_149, 30_004_150, 30_004_151, 30_004_152, 30_004_153, 30_004_154], 'influence' => 0.9, 'staging_solar_system_id' => 30_004_154, 'state' => 'mobilizing', 'type' => 'Incursion' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/incursions/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/incursions/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_incursions).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/incursions/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_incursions }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/incursions/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_incursions }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/incursions/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_incursions }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/industry_spec.rb
+++ b/spec/lib/esi/client/industry_spec.rb
@@ -1,548 +1,116 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Industry, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_industry_jobs" do
-    context "when the response is 200" do
-      let(:response) { [{ "activity_id" => 1, "blueprint_id" => 1_015_116_533_326, "blueprint_location_id" => 60_006_382, "blueprint_type_id" => 2047, "cost" => 118.01, "duration" => 548, "end_date" => "2014-07-19T15:56:14Z", "facility_id" => 60_006_382, "installer_id" => 498_338_451, "job_id" => 229_136_101, "licensed_runs" => 200, "output_location_id" => 60_006_382, "runs" => 1, "start_date" => "2014-07-19T15:47:06Z", "station_id" => 60_006_382, "status" => "active" }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_industry_jobs(character_id: "1234567890", include_completed: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_industry_jobs' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'activity_id' => 1, 'blueprint_id' => 1_015_116_533_326, 'blueprint_location_id' => 60_006_382, 'blueprint_type_id' => 2047, 'cost' => 118.01, 'duration' => 548, 'end_date' => '2014-07-19T15:56:14Z', 'facility_id' => 60_006_382, 'installer_id' => 498_338_451, 'job_id' => 229_136_101, 'licensed_runs' => 200, 'output_location_id' => 60_006_382, 'runs' => 1, 'start_date' => '2014-07-19T15:47:06Z', 'station_id' => 60_006_382, 'status' => 'active' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/industry/jobs/').with(query: { include_completed: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_industry_jobs(character_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_industry_jobs(character_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_industry_jobs(character_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_industry_jobs(character_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_industry_jobs(character_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_industry_jobs(character_id: '1234567890', include_completed: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_mining" do
-    context "when the response is 200" do
-      let(:response) { [{ "date" => "2017-09-19", "quantity" => 7004, "solar_system_id" => 30_003_707, "type_id" => 17_471 }, { "date" => "2017-09-18", "quantity" => 5199, "solar_system_id" => 30_003_707, "type_id" => 17_471 }] }
+  describe '#get_character_mining' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'date' => '2017-09-19', 'quantity' => 7004, 'solar_system_id' => 30_003_707, 'type_id' => 17_471 }, { 'date' => '2017-09-18', 'quantity' => 5199, 'solar_system_id' => 30_003_707, 'type_id' => 17_471 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mining/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/mining/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_mining(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mining/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_mining(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mining/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_mining(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mining/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_mining(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mining/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_mining(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mining/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_mining(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_mining(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_industry_jobs" do
-    context "when the response is 200" do
-      let(:response) { [{ "activity_id" => 1, "blueprint_id" => 1_015_116_533_326, "blueprint_location_id" => 60_006_382, "blueprint_type_id" => 2047, "cost" => 118.01, "duration" => 548, "end_date" => "2014-07-19T15:56:14Z", "facility_id" => 60_006_382, "installer_id" => 498_338_451, "job_id" => 229_136_101, "licensed_runs" => 200, "location_id" => 60_006_382, "output_location_id" => 60_006_382, "runs" => 1, "start_date" => "2014-07-19T15:47:06Z", "status" => "active" }] }
+  describe '#get_corporation_industry_jobs' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'activity_id' => 1, 'blueprint_id' => 1_015_116_533_326, 'blueprint_location_id' => 60_006_382, 'blueprint_type_id' => 2047, 'cost' => 118.01, 'duration' => 548, 'end_date' => '2014-07-19T15:56:14Z', 'facility_id' => 60_006_382, 'installer_id' => 498_338_451, 'job_id' => 229_136_101, 'licensed_runs' => 200, 'location_id' => 60_006_382, 'output_location_id' => 60_006_382, 'runs' => 1, 'start_date' => '2014-07-19T15:47:06Z', 'status' => 'active' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/industry/jobs/').with(query: { include_completed: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_industry_jobs(corporation_id: "1234567890", include_completed: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_industry_jobs(corporation_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_industry_jobs(corporation_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_industry_jobs(corporation_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_industry_jobs(corporation_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/industry/jobs/").with(query: { include_completed: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_industry_jobs(corporation_id: "1234567890", include_completed: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_industry_jobs(corporation_id: '1234567890', include_completed: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_mining_extractions" do
-    context "when the response is 200" do
-      let(:response) { [{ "chunk_arrival_time" => "2017-10-17T11:00:59Z", "extraction_start_time" => "2017-10-11T10:37:04Z", "moon_id" => 40_307_229, "natural_decay_time" => "2017-10-17T14:00:59Z", "structure_id" => 1_000_000_010_579 }] }
+  describe '#get_corporation_mining_extractions' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'chunk_arrival_time' => '2017-10-17T11:00:59Z', 'extraction_start_time' => '2017-10-11T10:37:04Z', 'moon_id' => 40_307_229, 'natural_decay_time' => '2017-10-17T14:00:59Z', 'structure_id' => 1_000_000_010_579 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/extractions/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporation/1234567890/mining/extractions/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_mining_extractions(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/extractions/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_mining_extractions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/extractions/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_mining_extractions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/extractions/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_mining_extractions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/extractions/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_mining_extractions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/extractions/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_mining_extractions(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_mining_extractions(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_mining_observer" do
-    context "when the response is 200" do
-      let(:response) { [{ "character_id" => 95_465_499, "last_updated" => "2017-09-19", "quantity" => 500, "recorded_corporation_id" => 109_299_958, "type_id" => 1230 }] }
+  describe '#get_corporation_mining_observer' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'character_id' => 95_465_499, 'last_updated' => '2017-09-19', 'quantity' => 500, 'recorded_corporation_id' => 109_299_958, 'type_id' => 1230 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporation/1234567890/mining/observers/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_mining_observer(corporation_id: "1234567890", observer_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_mining_observer(corporation_id: "1234567890", observer_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_mining_observer(corporation_id: "1234567890", observer_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_mining_observer(corporation_id: "1234567890", observer_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_mining_observer(corporation_id: "1234567890", observer_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_mining_observer(corporation_id: "1234567890", observer_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_mining_observer(corporation_id: '1234567890', observer_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_mining_observers" do
-    context "when the response is 200" do
-      let(:response) { [{ "last_updated" => "2017-09-19", "observer_id" => 1, "observer_type" => "structure" }] }
+  describe '#get_corporation_mining_observers' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'last_updated' => '2017-09-19', 'observer_id' => 1, 'observer_type' => 'structure' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporation/1234567890/mining/observers/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_mining_observers(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_mining_observers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_mining_observers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_mining_observers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_mining_observers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporation/1234567890/mining/observers/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_mining_observers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_mining_observers(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_industry_facilities" do
-    context "when the response is 200" do
-      let(:response) { [{ "facility_id" => 60_012_544, "owner_id" => 1_000_126, "region_id" => 10_000_001, "solar_system_id" => 30_000_032, "tax" => 0.1, "type_id" => 2502 }] }
+  describe '#get_industry_facilities' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'facility_id' => 60_012_544, 'owner_id' => 1_000_126, 'region_id' => 10_000_001, 'solar_system_id' => 30_000_032, 'tax' => 0.1, 'type_id' => 2502 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/industry/facilities/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/industry/facilities/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_industry_facilities).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/industry/facilities/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_industry_facilities }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/industry/facilities/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_industry_facilities }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/industry/facilities/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_industry_facilities }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_industry_systems" do
-    context "when the response is 200" do
-      let(:response) { [{ "cost_indices" => [{ "activity" => "invention", "cost_index" => 0.0048 }], "solar_system_id" => 30_011_392 }] }
+  describe '#get_industry_systems' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'cost_indices' => [{ 'activity' => 'invention', 'cost_index' => 0.0048 }], 'solar_system_id' => 30_011_392 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/industry/systems/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/industry/systems/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_industry_systems).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/industry/systems/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_industry_systems }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/industry/systems/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_industry_systems }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/industry/systems/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_industry_systems }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/insurance_spec.rb
+++ b/spec/lib/esi/client/insurance_spec.rb
@@ -1,54 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Insurance, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_insurance_prices" do
-    context "when the response is 200" do
-      let(:response) { [{ "levels" => [{ "cost" => 10.01, "name" => "Basic", "payout" => 20.01 }], "type_id" => 1 }] }
+  describe '#get_insurance_prices' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'levels' => [{ 'cost' => 10.01, 'name' => 'Basic', 'payout' => 20.01 }], 'type_id' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/insurance/prices/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/insurance/prices/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_insurance_prices).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/insurance/prices/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_insurance_prices }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/insurance/prices/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_insurance_prices }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/insurance/prices/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_insurance_prices }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/killmails_spec.rb
+++ b/spec/lib/esi/client/killmails_spec.rb
@@ -1,214 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Killmail, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_killmails_recent" do
-    context "when the response is 200" do
-      let(:response) { [{ "killmail_hash" => "8eef5e8fb6b88fe3407c489df33822b2e3b57a5e", "killmail_id" => 2 }, { "killmail_hash" => "b41ccb498ece33d64019f64c0db392aa3aa701fb", "killmail_id" => 1 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/killmails/recent/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_killmails_recent(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_killmails_recent' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'killmail_hash' => '8eef5e8fb6b88fe3407c489df33822b2e3b57a5e', 'killmail_id' => 2 }, { 'killmail_hash' => 'b41ccb498ece33d64019f64c0db392aa3aa701fb', 'killmail_id' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/killmails/recent/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/killmails/recent/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_killmails_recent(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/killmails/recent/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_killmails_recent(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/killmails/recent/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_killmails_recent(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/killmails/recent/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_killmails_recent(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/killmails/recent/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_killmails_recent(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_killmails_recent(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_killmails_recent" do
-    context "when the response is 200" do
-      let(:response) { [{ "killmail_hash" => "8eef5e8fb6b88fe3407c489df33822b2e3b57a5e", "killmail_id" => 2 }, { "killmail_hash" => "b41ccb498ece33d64019f64c0db392aa3aa701fb", "killmail_id" => 1 }] }
+  describe '#get_corporation_killmails_recent' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'killmail_hash' => '8eef5e8fb6b88fe3407c489df33822b2e3b57a5e', 'killmail_id' => 2 }, { 'killmail_hash' => 'b41ccb498ece33d64019f64c0db392aa3aa701fb', 'killmail_id' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/killmails/recent/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/killmails/recent/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_killmails_recent(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/killmails/recent/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_killmails_recent(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/killmails/recent/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_killmails_recent(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/killmails/recent/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_killmails_recent(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/killmails/recent/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_killmails_recent(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/killmails/recent/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_killmails_recent(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_killmails_recent(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_killmail_killmail_hash" do
-    context "when the response is 200" do
-      let(:response) { { "attackers" => [{ "character_id" => 95_810_944, "corporation_id" => 1_000_179, "damage_done" => 5745, "faction_id" => 500_003, "final_blow" => true, "security_status" => -0.3, "ship_type_id" => 17_841, "weapon_type_id" => 3074 }], "killmail_id" => 56_733_821, "killmail_time" => "2016-10-22T17:13:36Z", "solar_system_id" => 30_002_976, "victim" => { "alliance_id" => 621_338_554, "character_id" => 92_796_241, "corporation_id" => 841_363_671, "damage_taken" => 5745, "items" => [{ "flag" => 20, "item_type_id" => 5973, "quantity_dropped" => 1, "singleton" => 0 }], "position" => { "x" => 452_186_600_569.4748, "y" => 146_704_961_490.90222, "z" => 109_514_596_532.54477 }, "ship_type_id" => 17_812 } } }
+  describe '#get_killmail_killmail_hash' do
+    context 'when the response is 200' do
+      let(:response) { { 'attackers' => [{ 'character_id' => 95_810_944, 'corporation_id' => 1_000_179, 'damage_done' => 5745, 'faction_id' => 500_003, 'final_blow' => true, 'security_status' => -0.3, 'ship_type_id' => 17_841, 'weapon_type_id' => 3074 }], 'killmail_id' => 56_733_821, 'killmail_time' => '2016-10-22T17:13:36Z', 'solar_system_id' => 30_002_976, 'victim' => { 'alliance_id' => 621_338_554, 'character_id' => 92_796_241, 'corporation_id' => 841_363_671, 'damage_taken' => 5745, 'items' => [{ 'flag' => 20, 'item_type_id' => 5973, 'quantity_dropped' => 1, 'singleton' => 0 }], 'position' => { 'x' => 452_186_600_569.4748, 'y' => 146_704_961_490.90222, 'z' => 109_514_596_532.54477 }, 'ship_type_id' => 17_812 } } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/killmails/1234567890/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/killmails/1234567890/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_killmail_killmail_hash(killmail_hash: "1234567890", killmail_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/killmails/1234567890/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_killmail_killmail_hash(killmail_hash: "1234567890", killmail_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/killmails/1234567890/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_killmail_killmail_hash(killmail_hash: "1234567890", killmail_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "Unprocessable entity message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/killmails/1234567890/1234567890/").to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.get_killmail_killmail_hash(killmail_hash: "1234567890", killmail_id: "1234567890") }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/killmails/1234567890/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_killmail_killmail_hash(killmail_hash: "1234567890", killmail_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_killmail_killmail_hash(killmail_hash: '1234567890', killmail_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/location_spec.rb
+++ b/spec/lib/esi/client/location_spec.rb
@@ -1,226 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Location, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_location" do
-    context "when the response is 200" do
-      let(:response) { { "solar_system_id" => 30_002_505, "structure_id" => 1_000_000_016_989 } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/location/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_location(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_location' do
+    context 'when the response is 200' do
+      let(:response) { { 'solar_system_id' => 30_002_505, 'structure_id' => 1_000_000_016_989 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/location/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/location/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_location(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/location/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_location(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/location/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_location(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/location/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_location(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/location/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_location(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_location(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_online" do
-    context "when the response is 200" do
-      let(:response) { { "last_login" => "2017-01-02T03:04:05Z", "last_logout" => "2017-01-02T04:05:06Z", "logins" => 9001, "online" => true } }
+  describe '#get_character_online' do
+    context 'when the response is 200' do
+      let(:response) { { 'last_login' => '2017-01-02T03:04:05Z', 'last_logout' => '2017-01-02T04:05:06Z', 'logins' => 9001, 'online' => true } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/online/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/online/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_online(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/online/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_online(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/online/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_online(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/online/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_online(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/online/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_online(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/online/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_online(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_online(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_ship" do
-    context "when the response is 200" do
-      let(:response) { { "ship_item_id" => 1_000_000_016_991, "ship_name" => "SPACESHIPS!!!", "ship_type_id" => 1233 } }
+  describe '#get_character_ship' do
+    context 'when the response is 200' do
+      let(:response) { { 'ship_item_id' => 1_000_000_016_991, 'ship_name' => 'SPACESHIPS!!!', 'ship_type_id' => 1233 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/ship/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/ship/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_ship(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/ship/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_ship(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/ship/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_ship(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/ship/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_ship(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/ship/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_ship(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/ship/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_ship(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_ship(character_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/loyalty_spec.rb
+++ b/spec/lib/esi/client/loyalty_spec.rb
@@ -1,140 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Loyalty, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_loyalty_points" do
-    context "when the response is 200" do
-      let(:response) { [{ "corporation_id" => 123, "loyalty_points" => 100 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/loyalty/points/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_loyalty_points(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_loyalty_points' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'corporation_id' => 123, 'loyalty_points' => 100 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/loyalty/points/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/loyalty/points/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_loyalty_points(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/loyalty/points/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_loyalty_points(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/loyalty/points/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_loyalty_points(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/loyalty/points/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_loyalty_points(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/loyalty/points/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_loyalty_points(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_loyalty_points(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_loyalty_stores_corporation_offers" do
-    context "when the response is 200" do
-      let(:response) { [{ "ak_cost" => 35_000, "isk_cost" => 0, "lp_cost" => 100, "offer_id" => 1, "quantity" => 1, "required_items" => [], "type_id" => 123 }, { "isk_cost" => 1000, "lp_cost" => 100, "offer_id" => 2, "quantity" => 10, "required_items" => [{ "quantity" => 10, "type_id" => 1234 }], "type_id" => 1235 }] }
+  describe '#get_loyalty_stores_corporation_offers' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'ak_cost' => 35_000, 'isk_cost' => 0, 'lp_cost' => 100, 'offer_id' => 1, 'quantity' => 1, 'required_items' => [], 'type_id' => 123 }, { 'isk_cost' => 1000, 'lp_cost' => 100, 'offer_id' => 2, 'quantity' => 10, 'required_items' => [{ 'quantity' => 10, 'type_id' => 1234 }], 'type_id' => 1235 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/loyalty/stores/1234567890/offers/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/loyalty/stores/1234567890/offers/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_loyalty_stores_corporation_offers(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/loyalty/stores/1234567890/offers/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_loyalty_stores_corporation_offers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/loyalty/stores/1234567890/offers/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_loyalty_stores_corporation_offers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/loyalty/stores/1234567890/offers/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_loyalty_stores_corporation_offers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/loyalty/stores/1234567890/offers/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_loyalty_stores_corporation_offers(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_loyalty_stores_corporation_offers(corporation_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/mail_spec.rb
+++ b/spec/lib/esi/client/mail_spec.rb
@@ -1,632 +1,116 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Mail, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#delete_character_mail" do
-    context "when the response is 204" do
+  describe '#delete_character_mail' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:delete, 'https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.delete_character_mail(character_id: "1234567890", mail_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.delete_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.delete_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.delete_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.delete_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.delete_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.delete_character_mail(character_id: '1234567890', mail_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#delete_character_mail_label" do
-    context "when the response is 204" do
+  describe '#delete_character_mail_label' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:delete, 'https://esi.evetech.net/latest/characters/1234567890/mail/labels/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.delete_character_mail_label(character_id: "1234567890", label_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.delete_character_mail_label(character_id: "1234567890", label_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.delete_character_mail_label(character_id: "1234567890", label_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.delete_character_mail_label(character_id: "1234567890", label_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.delete_character_mail_label(character_id: "1234567890", label_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "Unprocessable entity message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/1234567890/").to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.delete_character_mail_label(character_id: "1234567890", label_id: "1234567890") }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:delete, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.delete_character_mail_label(character_id: "1234567890", label_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.delete_character_mail_label(character_id: '1234567890', label_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_mail" do
-    context "when the response is 200" do
-      let(:response) { { "body" => "blah blah blah", "from" => 90_000_001, "labels" => [2, 32], "read" => true, "subject" => "test", "timestamp" => "2015-09-30T16:07:00Z" } }
+  describe '#get_character_mail' do
+    context 'when the response is 200' do
+      let(:response) { { 'body' => 'blah blah blah', 'from' => 90_000_001, 'labels' => [2, 32], 'read' => true, 'subject' => 'test', 'timestamp' => '2015-09-30T16:07:00Z' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_mail(character_id: "1234567890", mail_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_mail(character_id: "1234567890", mail_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_mail(character_id: '1234567890', mail_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_mail_labels" do
-    context "when the response is 200" do
-      let(:response) { { "labels" => [{ "color" => "#660066", "label_id" => 16, "name" => "PINK", "unread_count" => 4 }, { "color" => "#ffffff", "label_id" => 17, "name" => "WHITE", "unread_count" => 1 }], "total_unread_count" => 5 } }
+  describe '#get_character_mail_labels' do
+    context 'when the response is 200' do
+      let(:response) { { 'labels' => [{ 'color' => '#660066', 'label_id' => 16, 'name' => 'PINK', 'unread_count' => 4 }, { 'color' => '#ffffff', 'label_id' => 17, 'name' => 'WHITE', 'unread_count' => 1 }], 'total_unread_count' => 5 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/mail/labels/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_mail_labels(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_mail_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_mail_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_mail_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_mail_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_mail_labels(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_mail_labels(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_mail_lists" do
-    context "when the response is 200" do
-      let(:response) { [{ "mailing_list_id" => 1, "name" => "test_mailing_list" }] }
+  describe '#get_character_mail_lists' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'mailing_list_id' => 1, 'name' => 'test_mailing_list' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/lists/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/mail/lists/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_mail_lists(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/lists/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_mail_lists(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/lists/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_mail_lists(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/lists/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_mail_lists(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/lists/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_mail_lists(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/mail/lists/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_mail_lists(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_mail_lists(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_character_mail" do
-    context "when the response is 201" do
+  describe '#post_character_mail' do
+    context 'when the response is 201' do
       let(:response) { 13 }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/characters/1234567890/mail/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_character_mail(character_id: "1234567890", mail: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_character_mail(character_id: "1234567890", mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_character_mail(character_id: "1234567890", mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_character_mail(character_id: "1234567890", mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_character_mail(character_id: "1234567890", mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_character_mail(character_id: "1234567890", mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-
-    context "when the response is 520" do
-      let(:response) { { "error" => "Error 520 message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/").to_return(body: response.to_json, status: 520, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::EveServerError error" do
-        expect { client.post_character_mail(character_id: "1234567890", mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::EveServerError)
+      it 'returns the response' do
+        expect(client.post_character_mail(character_id: '1234567890', mail: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end
 
-  describe "#post_character_mail_labels" do
-    context "when the response is 201" do
+  describe '#post_character_mail_labels' do
+    context 'when the response is 201' do
       let(:response) { 128 }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/characters/1234567890/mail/labels/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_character_mail_labels(character_id: "1234567890", label: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_character_mail_labels(character_id: "1234567890", label: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_character_mail_labels(character_id: "1234567890", label: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_character_mail_labels(character_id: "1234567890", label: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_character_mail_labels(character_id: "1234567890", label: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/characters/1234567890/mail/labels/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_character_mail_labels(character_id: "1234567890", label: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_character_mail_labels(character_id: '1234567890', label: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end
 
-  describe "#put_character_mail" do
-    context "when the response is 204" do
+  describe '#put_character_mail' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:put, 'https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.put_character_mail(character_id: "1234567890", mail_id: "1234567890", contents: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.put_character_mail(character_id: "1234567890", mail_id: "1234567890", contents: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.put_character_mail(character_id: "1234567890", mail_id: "1234567890", contents: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.put_character_mail(character_id: "1234567890", mail_id: "1234567890", contents: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.put_character_mail(character_id: "1234567890", mail_id: "1234567890", contents: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:put, "https://esi.evetech.net/latest/characters/1234567890/mail/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.put_character_mail(character_id: "1234567890", mail_id: "1234567890", contents: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.put_character_mail(character_id: '1234567890', mail_id: '1234567890', contents: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/market_spec.rb
+++ b/spec/lib/esi/client/market_spec.rb
@@ -1,746 +1,158 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Market, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_orders" do
-    context "when the response is 200" do
-      let(:response) { [{ "duration" => 30, "escrow" => 45.6, "is_buy_order" => true, "is_corporation" => false, "issued" => "2016-09-03T05:12:25Z", "location_id" => 456, "min_volume" => 1, "order_id" => 123, "price" => 33.3, "range" => "station", "region_id" => 123, "type_id" => 456, "volume_remain" => 4422, "volume_total" => 123_456 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_orders(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_orders' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'duration' => 30, 'escrow' => 45.6, 'is_buy_order' => true, 'is_corporation' => false, 'issued' => '2016-09-03T05:12:25Z', 'location_id' => 456, 'min_volume' => 1, 'order_id' => 123, 'price' => 33.3, 'range' => 'station', 'region_id' => 123, 'type_id' => 456, 'volume_remain' => 4422, 'volume_total' => 123_456 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/orders/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_orders(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_orders(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_orders(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_orders(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_orders(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_orders(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_orders_history" do
-    context "when the response is 200" do
-      let(:response) { [{ "duration" => 30, "escrow" => 45.6, "is_buy_order" => true, "is_corporation" => false, "issued" => "2016-09-03T05:12:25Z", "location_id" => 456, "min_volume" => 1, "order_id" => 123, "price" => 33.3, "range" => "station", "region_id" => 123, "state" => "expired", "type_id" => 456, "volume_remain" => 4422, "volume_total" => 123_456 }] }
+  describe '#get_character_orders_history' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'duration' => 30, 'escrow' => 45.6, 'is_buy_order' => true, 'is_corporation' => false, 'issued' => '2016-09-03T05:12:25Z', 'location_id' => 456, 'min_volume' => 1, 'order_id' => 123, 'price' => 33.3, 'range' => 'station', 'region_id' => 123, 'state' => 'expired', 'type_id' => 456, 'volume_remain' => 4422, 'volume_total' => 123_456 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/history/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/orders/history/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_orders_history(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/history/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_orders_history(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/history/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_orders_history(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/history/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_orders_history(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/history/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_orders_history(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/orders/history/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_orders_history(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_orders_history(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_orders" do
-    context "when the response is 200" do
-      let(:response) { [{ "duration" => 30, "escrow" => 45.6, "is_buy_order" => true, "issued" => "2016-09-03T05:12:25Z", "issued_by" => 2_112_625_428, "location_id" => 456, "min_volume" => 1, "order_id" => 123, "price" => 33.3, "range" => "station", "region_id" => 123, "type_id" => 456, "volume_remain" => 4422, "volume_total" => 123_456, "wallet_division" => 1 }] }
+  describe '#get_corporation_orders' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'duration' => 30, 'escrow' => 45.6, 'is_buy_order' => true, 'issued' => '2016-09-03T05:12:25Z', 'issued_by' => 2_112_625_428, 'location_id' => 456, 'min_volume' => 1, 'order_id' => 123, 'price' => 33.3, 'range' => 'station', 'region_id' => 123, 'type_id' => 456, 'volume_remain' => 4422, 'volume_total' => 123_456, 'wallet_division' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/orders/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_orders(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_orders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_orders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_orders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_orders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_orders(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_orders(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_orders_history" do
-    context "when the response is 200" do
-      let(:response) { [{ "duration" => 30, "escrow" => 45.6, "is_buy_order" => true, "issued" => "2016-09-03T05:12:25Z", "issued_by" => 2_112_625_428, "location_id" => 456, "min_volume" => 1, "order_id" => 123, "price" => 33.3, "range" => "station", "region_id" => 123, "state" => "expired", "type_id" => 456, "volume_remain" => 4422, "volume_total" => 123_456, "wallet_division" => 1 }] }
+  describe '#get_corporation_orders_history' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'duration' => 30, 'escrow' => 45.6, 'is_buy_order' => true, 'issued' => '2016-09-03T05:12:25Z', 'issued_by' => 2_112_625_428, 'location_id' => 456, 'min_volume' => 1, 'order_id' => 123, 'price' => 33.3, 'range' => 'station', 'region_id' => 123, 'state' => 'expired', 'type_id' => 456, 'volume_remain' => 4422, 'volume_total' => 123_456, 'wallet_division' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/history/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/orders/history/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_orders_history(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/history/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_orders_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/history/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_orders_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/history/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_orders_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/history/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_orders_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/orders/history/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_orders_history(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_orders_history(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_market_groups" do
-    context "when the response is 200" do
+  describe '#get_market_groups' do
+    context 'when the response is 200' do
       let(:response) { [1, 2, 3] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/groups/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_market_groups).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_market_groups }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_market_groups_market_group' do
+    context 'when the response is 200' do
+      let(:response) { { 'description' => 'Small, fast vessels suited to a variety of purposes.', 'market_group_id' => 5, 'name' => 'Standard Frigates', 'parent_group_id' => 1361, 'types' => [582, 583] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/groups/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_market_groups }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_market_groups }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_market_groups_market_group(market_group_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_market_groups_market_group" do
-    context "when the response is 200" do
-      let(:response) { { "description" => "Small, fast vessels suited to a variety of purposes.", "market_group_id" => 5, "name" => "Standard Frigates", "parent_group_id" => 1361, "types" => [582, 583] } }
+  describe '#get_market_prices' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'adjusted_price' => 306_988.09, 'average_price' => 306_292.67, 'type_id' => 32_772 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/prices/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_market_groups_market_group(market_group_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_market_groups_market_group(market_group_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_market_groups_market_group(market_group_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_market_groups_market_group(market_group_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/groups/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_market_groups_market_group(market_group_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_market_prices" do
-    context "when the response is 200" do
-      let(:response) { [{ "adjusted_price" => 306_988.09, "average_price" => 306_292.67, "type_id" => 32_772 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/prices/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_market_prices).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/prices/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_market_prices }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_markets_region_history' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'average' => 5.25, 'date' => '2015-05-01', 'highest' => 5.27, 'lowest' => 5.11, 'order_count' => 2267, 'volume' => 16_276_782_035 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/prices/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/history/').with(query: { type_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_market_prices }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/prices/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_market_prices }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_markets_region_history(region_id: '1234567890', type_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_markets_region_history" do
-    context "when the response is 200" do
-      let(:response) { [{ "average" => 5.25, "date" => "2015-05-01", "highest" => 5.27, "lowest" => 5.11, "order_count" => 2267, "volume" => 16_276_782_035 }] }
+  describe '#get_markets_region_orders' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'duration' => 90, 'is_buy_order' => false, 'issued' => '2016-09-03T05:12:25Z', 'location_id' => 60_005_599, 'min_volume' => 1, 'order_id' => 4_623_824_223, 'price' => 9.9, 'range' => 'region', 'system_id' => 30_000_053, 'type_id' => 34, 'volume_remain' => 1_296_000, 'volume_total' => 2_000_000 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/history/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_markets_region_history(region_id: "1234567890", type_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/history/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_markets_region_history(region_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/history/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_markets_region_history(region_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/history/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_markets_region_history(region_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "Unprocessable entity message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/history/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.get_markets_region_history(region_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/history/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_markets_region_history(region_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-
-    context "when the response is 520" do
-      let(:response) { { "error" => "Error 520 message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/history/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 520, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::EveServerError error" do
-        expect { client.get_markets_region_history(region_id: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::EveServerError)
+      it 'returns the response' do
+        expect(client.get_markets_region_orders(region_id: '1234567890', order_type: '1234567890', type_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_markets_region_orders" do
-    context "when the response is 200" do
-      let(:response) { [{ "duration" => 90, "is_buy_order" => false, "issued" => "2016-09-03T05:12:25Z", "location_id" => 60_005_599, "min_volume" => 1, "order_id" => 4_623_824_223, "price" => 9.9, "range" => "region", "system_id" => 30_000_053, "type_id" => 34, "volume_remain" => 1_296_000, "volume_total" => 2_000_000 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/orders/").with(query: { order_type: "1234567890", type_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
-      end
-
-      it "returns the response" do
-        expect(client.get_markets_region_orders(region_id: "1234567890", order_type: "1234567890", type_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/orders/").with(query: { order_type: "1234567890", type_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_markets_region_orders(region_id: "1234567890", order_type: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/orders/").with(query: { order_type: "1234567890", type_id: "1234567890" }).to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_markets_region_orders(region_id: "1234567890", order_type: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/orders/").with(query: { order_type: "1234567890", type_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_markets_region_orders(region_id: "1234567890", order_type: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "Unprocessable entity message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/orders/").with(query: { order_type: "1234567890", type_id: "1234567890" }).to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.get_markets_region_orders(region_id: "1234567890", order_type: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/orders/").with(query: { order_type: "1234567890", type_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_markets_region_orders(region_id: "1234567890", order_type: "1234567890", type_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_markets_region_types" do
-    context "when the response is 200" do
+  describe '#get_markets_region_types' do
+    context 'when the response is 200' do
       let(:response) { [587, 593, 597] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/types/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/types/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_markets_region_types(region_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/types/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_markets_region_types(region_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/types/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_markets_region_types(region_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/1234567890/types/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_markets_region_types(region_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_markets_region_types(region_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_markets_structure" do
-    context "when the response is 200" do
-      let(:response) { [{ "duration" => 90, "is_buy_order" => false, "issued" => "2016-09-03T05:12:25Z", "location_id" => 1_020_988_381_992, "min_volume" => 1, "order_id" => 4_623_824_223, "price" => 9.9, "range" => "region", "type_id" => 34, "volume_remain" => 1_296_000, "volume_total" => 2_000_000 }] }
+  describe '#get_markets_structure' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'duration' => 90, 'is_buy_order' => false, 'issued' => '2016-09-03T05:12:25Z', 'location_id' => 1_020_988_381_992, 'min_volume' => 1, 'order_id' => 4_623_824_223, 'price' => 9.9, 'range' => 'region', 'type_id' => 34, 'volume_remain' => 1_296_000, 'volume_total' => 2_000_000 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/structures/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/structures/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_markets_structure(structure_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/structures/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_markets_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/structures/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_markets_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/structures/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_markets_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/structures/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_markets_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/markets/structures/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_markets_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_markets_structure(structure_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/opportunities_spec.rb
+++ b/spec/lib/esi/client/opportunities_spec.rb
@@ -1,278 +1,74 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Opportunity, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_opportunities" do
-    context "when the response is 200" do
-      let(:response) { [{ "completed_at" => "2016-04-29T12:34:56Z", "task_id" => 1 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/opportunities/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_opportunities(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_opportunities' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'completed_at' => '2016-04-29T12:34:56Z', 'task_id' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/opportunities/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/opportunities/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_opportunities(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/opportunities/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_opportunities(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/opportunities/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_opportunities(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/opportunities/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_opportunities(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/opportunities/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_opportunities(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_opportunities(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_opportunities_group" do
-    context "when the response is 200" do
-      let(:response) { { "connected_groups" => [100], "description" => "As a capsuleer...", "group_id" => 103, "name" => "Welcome to New Eden", "notification" => "Completed:<br>Welcome to New Eden", "required_tasks" => [19] } }
+  describe '#get_opportunities_group' do
+    context 'when the response is 200' do
+      let(:response) { { 'connected_groups' => [100], 'description' => 'As a capsuleer...', 'group_id' => 103, 'name' => 'Welcome to New Eden', 'notification' => 'Completed:<br>Welcome to New Eden', 'required_tasks' => [19] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/groups/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/opportunities/groups/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_opportunities_group(group_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/groups/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_opportunities_group(group_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/groups/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_opportunities_group(group_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/groups/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_opportunities_group(group_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_opportunities_group(group_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_opportunities_task" do
-    context "when the response is 200" do
-      let(:response) { { "description" => "To use station services...", "name" => "Dock in the station", "notification" => "Completed:<br>Docked in a station!", "task_id" => 10 } }
+  describe '#get_opportunities_task' do
+    context 'when the response is 200' do
+      let(:response) { { 'description' => 'To use station services...', 'name' => 'Dock in the station', 'notification' => 'Completed:<br>Docked in a station!', 'task_id' => 10 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/tasks/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/opportunities/tasks/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_opportunities_task(task_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/tasks/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_opportunities_task(task_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/tasks/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_opportunities_task(task_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/tasks/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_opportunities_task(task_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_opportunities_task(task_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_opportunity_groups" do
-    context "when the response is 200" do
+  describe '#get_opportunity_groups' do
+    context 'when the response is 200' do
       let(:response) { [100, 101, 102, 103] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/groups/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/opportunities/groups/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_opportunity_groups).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/groups/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_opportunity_groups }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/groups/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_opportunity_groups }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/groups/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_opportunity_groups }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end
 
-  describe "#get_opportunity_tasks" do
-    context "when the response is 200" do
+  describe '#get_opportunity_tasks' do
+    context 'when the response is 200' do
       let(:response) { [1, 2, 3, 4] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/tasks/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/opportunities/tasks/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_opportunity_tasks).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/tasks/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_opportunity_tasks }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/tasks/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_opportunity_tasks }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/opportunities/tasks/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_opportunity_tasks }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/planetary_interaction_spec.rb
+++ b/spec/lib/esi/client/planetary_interaction_spec.rb
@@ -1,300 +1,60 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::PlanetaryInteraction, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_planet" do
-    context "when the response is 200" do
-      let(:response) { { "links" => [{ "destination_pin_id" => 1_000_000_017_022, "link_level" => 0, "source_pin_id" => 1_000_000_017_021 }], "pins" => [{ "latitude" => 1.55087844973, "longitude" => 0.717145933308, "pin_id" => 1_000_000_017_021, "type_id" => 2254 }, { "latitude" => 1.53360639935, "longitude" => 0.709775584394, "pin_id" => 1_000_000_017_022, "type_id" => 2256 }], "routes" => [{ "content_type_id" => 2393, "destination_pin_id" => 1_000_000_017_030, "quantity" => 20, "route_id" => 4, "source_pin_id" => 1_000_000_017_029 }] } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_planet(character_id: "1234567890", planet_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_planet' do
+    context 'when the response is 200' do
+      let(:response) { { 'links' => [{ 'destination_pin_id' => 1_000_000_017_022, 'link_level' => 0, 'source_pin_id' => 1_000_000_017_021 }], 'pins' => [{ 'latitude' => 1.55087844973, 'longitude' => 0.717145933308, 'pin_id' => 1_000_000_017_021, 'type_id' => 2254 }, { 'latitude' => 1.53360639935, 'longitude' => 0.709775584394, 'pin_id' => 1_000_000_017_022, 'type_id' => 2256 }], 'routes' => [{ 'content_type_id' => 2393, 'destination_pin_id' => 1_000_000_017_030, 'quantity' => 20, 'route_id' => 4, 'source_pin_id' => 1_000_000_017_029 }] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/planets/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_planet(character_id: "1234567890", planet_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_planet(character_id: "1234567890", planet_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_planet(character_id: "1234567890", planet_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Colony not found" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_character_planet(character_id: "1234567890", planet_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_planet(character_id: "1234567890", planet_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_planet(character_id: "1234567890", planet_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_planet(character_id: '1234567890', planet_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_planets" do
-    context "when the response is 200" do
-      let(:response) { [{ "last_update" => "2016-11-28T16:42:51Z", "num_pins" => 1, "owner_id" => 90_000_001, "planet_id" => 40_023_691, "planet_type" => "plasma", "solar_system_id" => 30_000_379, "upgrade_level" => 0 }, { "last_update" => "2016-11-28T16:41:54Z", "num_pins" => 1, "owner_id" => 90_000_001, "planet_id" => 40_023_697, "planet_type" => "barren", "solar_system_id" => 30_000_379, "upgrade_level" => 0 }] }
+  describe '#get_character_planets' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'last_update' => '2016-11-28T16:42:51Z', 'num_pins' => 1, 'owner_id' => 90_000_001, 'planet_id' => 40_023_691, 'planet_type' => 'plasma', 'solar_system_id' => 30_000_379, 'upgrade_level' => 0 }, { 'last_update' => '2016-11-28T16:41:54Z', 'num_pins' => 1, 'owner_id' => 90_000_001, 'planet_id' => 40_023_697, 'planet_type' => 'barren', 'solar_system_id' => 30_000_379, 'upgrade_level' => 0 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/planets/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_planets(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_planets(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_planets(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_planets(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_planets(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/planets/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_planets(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_planets(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_customs_offices" do
-    context "when the response is 200" do
-      let(:response) { [{ "alliance_tax_rate" => 0.1, "allow_access_with_standings" => true, "allow_alliance_access" => false, "corporation_tax_rate" => 0.02, "excellent_standing_tax_rate" => 0.05, "good_standing_tax_rate" => 0.2, "neutral_standing_tax_rate" => 0.5, "office_id" => 1_000_000_014_530, "reinforce_exit_end" => 1, "reinforce_exit_start" => 23, "standing_level" => "neutral", "system_id" => 30_003_657 }] }
+  describe '#get_corporation_customs_offices' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'alliance_tax_rate' => 0.1, 'allow_access_with_standings' => true, 'allow_alliance_access' => false, 'corporation_tax_rate' => 0.02, 'excellent_standing_tax_rate' => 0.05, 'good_standing_tax_rate' => 0.2, 'neutral_standing_tax_rate' => 0.5, 'office_id' => 1_000_000_014_530, 'reinforce_exit_end' => 1, 'reinforce_exit_start' => 23, 'standing_level' => 'neutral', 'system_id' => 30_003_657 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/customs_offices/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/customs_offices/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_customs_offices(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/customs_offices/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_customs_offices(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/customs_offices/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_customs_offices(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/customs_offices/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_customs_offices(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/customs_offices/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_customs_offices(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/customs_offices/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_customs_offices(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_customs_offices(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_schematic" do
-    context "when the response is 200" do
-      let(:response) { { "cycle_time" => 1800, "schematic_name" => "Bacteria" } }
+  describe '#get_universe_schematic' do
+    context 'when the response is 200' do
+      let(:response) { { 'cycle_time' => 1800, 'schematic_name' => 'Bacteria' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/schematics/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/schematics/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_schematic(schematic_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/schematics/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_schematic(schematic_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Schematic not found" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/schematics/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_schematic(schematic_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/schematics/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_schematic(schematic_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/schematics/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_schematic(schematic_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_schematic(schematic_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/routes_spec.rb
+++ b/spec/lib/esi/client/routes_spec.rb
@@ -1,66 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Route, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_route_origin_destination" do
-    context "when the response is 200" do
+  describe '#get_route_origin_destination' do
+    context 'when the response is 200' do
       let(:response) { [30_002_771, 30_002_770, 30_002_769, 30_002_772] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/route/1234567890/1234567890/").with(query: { avoid: "1234567890", connections: "1234567890", flag: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/route/1234567890/1234567890/').with(query: { avoid: '1234567890', connections: '1234567890', flag: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_route_origin_destination(destination: "1234567890", origin: "1234567890", avoid: "1234567890", connections: "1234567890", flag: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/route/1234567890/1234567890/").with(query: { avoid: "1234567890", connections: "1234567890", flag: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_route_origin_destination(destination: "1234567890", origin: "1234567890", avoid: "1234567890", connections: "1234567890", flag: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/route/1234567890/1234567890/").with(query: { avoid: "1234567890", connections: "1234567890", flag: "1234567890" }).to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_route_origin_destination(destination: "1234567890", origin: "1234567890", avoid: "1234567890", connections: "1234567890", flag: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/route/1234567890/1234567890/").with(query: { avoid: "1234567890", connections: "1234567890", flag: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_route_origin_destination(destination: "1234567890", origin: "1234567890", avoid: "1234567890", connections: "1234567890", flag: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/route/1234567890/1234567890/").with(query: { avoid: "1234567890", connections: "1234567890", flag: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_route_origin_destination(destination: "1234567890", origin: "1234567890", avoid: "1234567890", connections: "1234567890", flag: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_route_origin_destination(destination: '1234567890', origin: '1234567890', avoid: '1234567890', connections: '1234567890', flag: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/search_spec.rb
+++ b/spec/lib/esi/client/search_spec.rb
@@ -1,128 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Search, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_search" do
-    context "when the response is 200" do
-      let(:response) { { "solar_system" => [30_002_510], "station" => [60_004_588, 60_004_594, 60_005_725, 60_009_106, 60_012_721, 60_012_724, 60_012_727] } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_search(character_id: "1234567890", categories: "1234567890", search: "1234567890", strict: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_search' do
+    context 'when the response is 200' do
+      let(:response) { { 'solar_system' => [30_002_510], 'station' => [60_004_588, 60_004_594, 60_005_725, 60_009_106, 60_012_721, 60_012_724, 60_012_727] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/search/').with(query: { categories: '1234567890', search: '1234567890', strict: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_search(character_id: "1234567890", categories: "1234567890", search: "1234567890", strict: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_search(character_id: "1234567890", categories: "1234567890", search: "1234567890", strict: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_search(character_id: "1234567890", categories: "1234567890", search: "1234567890", strict: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_search(character_id: "1234567890", categories: "1234567890", search: "1234567890", strict: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_search(character_id: "1234567890", categories: "1234567890", search: "1234567890", strict: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_search(character_id: '1234567890', categories: '1234567890', search: '1234567890', strict: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_search" do
-    context "when the response is 200" do
-      let(:response) { { "solar_system" => [30_002_510], "station" => [60_004_588, 60_004_594, 60_005_725, 60_009_106, 60_012_721, 60_012_724, 60_012_727] } }
+  describe '#get_search' do
+    context 'when the response is 200' do
+      let(:response) { { 'solar_system' => [30_002_510], 'station' => [60_004_588, 60_004_594, 60_005_725, 60_009_106, 60_012_721, 60_012_724, 60_012_727] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/search/').with(query: { categories: '1234567890', search: '1234567890', strict: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_search(categories: "1234567890", search: "1234567890", strict: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_search(categories: "1234567890", search: "1234567890", strict: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_search(categories: "1234567890", search: "1234567890", strict: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/search/").with(query: { categories: "1234567890", search: "1234567890", strict: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_search(categories: "1234567890", search: "1234567890", strict: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_search(categories: '1234567890', search: '1234567890', strict: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/skills_spec.rb
+++ b/spec/lib/esi/client/skills_spec.rb
@@ -1,226 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Skill, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_attributes" do
-    context "when the response is 200" do
-      let(:response) { { "charisma" => 20, "intelligence" => 20, "memory" => 20, "perception" => 20, "willpower" => 20 } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/attributes/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_character_attributes(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_character_attributes' do
+    context 'when the response is 200' do
+      let(:response) { { 'charisma' => 20, 'intelligence' => 20, 'memory' => 20, 'perception' => 20, 'willpower' => 20 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/attributes/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/attributes/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_attributes(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/attributes/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_attributes(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/attributes/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_attributes(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/attributes/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_attributes(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/attributes/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_attributes(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_attributes(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_skillqueue" do
-    context "when the response is 200" do
-      let(:response) { [{ "finish_date" => "2016-06-29T10:47:00Z", "finished_level" => 3, "queue_position" => 0, "skill_id" => 1, "start_date" => "2016-06-29T10:46:00Z" }, { "finish_date" => "2016-07-15T10:47:00Z", "finished_level" => 4, "queue_position" => 1, "skill_id" => 1, "start_date" => "2016-06-29T10:47:00Z" }, { "finish_date" => "2016-08-30T10:47:00Z", "finished_level" => 2, "queue_position" => 2, "skill_id" => 2, "start_date" => "2016-07-15T10:47:00Z" }] }
+  describe '#get_character_skillqueue' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'finish_date' => '2016-06-29T10:47:00Z', 'finished_level' => 3, 'queue_position' => 0, 'skill_id' => 1, 'start_date' => '2016-06-29T10:46:00Z' }, { 'finish_date' => '2016-07-15T10:47:00Z', 'finished_level' => 4, 'queue_position' => 1, 'skill_id' => 1, 'start_date' => '2016-06-29T10:47:00Z' }, { 'finish_date' => '2016-08-30T10:47:00Z', 'finished_level' => 2, 'queue_position' => 2, 'skill_id' => 2, 'start_date' => '2016-07-15T10:47:00Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skillqueue/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/skillqueue/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_skillqueue(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skillqueue/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_skillqueue(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skillqueue/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_skillqueue(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skillqueue/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_skillqueue(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skillqueue/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_skillqueue(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skillqueue/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_skillqueue(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_skillqueue(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_skills" do
-    context "when the response is 200" do
-      let(:response) { { "skills" => [{ "active_skill_level" => 3, "skill_id" => 1, "skillpoints_in_skill" => 10_000, "trained_skill_level" => 4 }, { "active_skill_level" => 1, "skill_id" => 2, "skillpoints_in_skill" => 10_000, "trained_skill_level" => 1 }], "total_sp" => 20_000 } }
+  describe '#get_character_skills' do
+    context 'when the response is 200' do
+      let(:response) { { 'skills' => [{ 'active_skill_level' => 3, 'skill_id' => 1, 'skillpoints_in_skill' => 10_000, 'trained_skill_level' => 4 }, { 'active_skill_level' => 1, 'skill_id' => 2, 'skillpoints_in_skill' => 10_000, 'trained_skill_level' => 1 }], 'total_sp' => 20_000 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skills/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/skills/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_skills(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skills/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_skills(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skills/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_skills(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skills/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_skills(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skills/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_skills(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/skills/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_skills(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_skills(character_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/sovereignty_spec.rb
+++ b/spec/lib/esi/client/sovereignty_spec.rb
@@ -1,154 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Sovereignty, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_sovereignty_campaigns" do
-    context "when the response is 200" do
-      let(:response) { [{ "attackers_score" => 0.4, "campaign_id" => 32_833, "constellation_id" => 20_000_125, "defender_id" => 1_695_357_456, "defender_score" => 0.6, "event_type" => "station_defense", "solar_system_id" => 30_000_856, "start_time" => "2016-10-29T14:34:40Z", "structure_id" => 61_001_096 }] }
+  describe '#get_sovereignty_campaigns' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'attackers_score' => 0.4, 'campaign_id' => 32_833, 'constellation_id' => 20_000_125, 'defender_id' => 1_695_357_456, 'defender_score' => 0.6, 'event_type' => 'station_defense', 'solar_system_id' => 30_000_856, 'start_time' => '2016-10-29T14:34:40Z', 'structure_id' => 61_001_096 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/campaigns/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/sovereignty/campaigns/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_sovereignty_campaigns).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/campaigns/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_sovereignty_campaigns }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/campaigns/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_sovereignty_campaigns }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/campaigns/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_sovereignty_campaigns }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_sovereignty_map" do
-    context "when the response is 200" do
-      let(:response) { [{ "faction_id" => 500_001, "system_id" => 30_045_334 }] }
+  describe '#get_sovereignty_map' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'faction_id' => 500_001, 'system_id' => 30_045_334 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/map/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/sovereignty/map/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_sovereignty_map).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/map/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_sovereignty_map }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/map/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_sovereignty_map }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/map/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_sovereignty_map }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_sovereignty_structures" do
-    context "when the response is 200" do
-      let(:response) { [{ "alliance_id" => 498_125_261, "solar_system_id" => 30_000_570, "structure_id" => 1_018_253_388_776, "structure_type_id" => 32_226, "vulnerability_occupancy_level" => 2, "vulnerable_end_time" => "2016-10-29T05:30:00Z", "vulnerable_start_time" => "2016-10-28T20:30:00Z" }] }
+  describe '#get_sovereignty_structures' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'alliance_id' => 498_125_261, 'solar_system_id' => 30_000_570, 'structure_id' => 1_018_253_388_776, 'structure_type_id' => 32_226, 'vulnerability_occupancy_level' => 2, 'vulnerable_end_time' => '2016-10-29T05:30:00Z', 'vulnerable_start_time' => '2016-10-28T20:30:00Z' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/structures/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/sovereignty/structures/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_sovereignty_structures).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/structures/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_sovereignty_structures }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/structures/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_sovereignty_structures }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/sovereignty/structures/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_sovereignty_structures }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/status_spec.rb
+++ b/spec/lib/esi/client/status_spec.rb
@@ -1,54 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Status, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_status" do
-    context "when the response is 200" do
-      let(:response) { { "players" => 12_345, "server_version" => "1132976", "start_time" => "2017-01-02T12:34:56Z" } }
+  describe '#get_status' do
+    context 'when the response is 200' do
+      let(:response) { { 'players' => 12_345, 'server_version' => '1132976', 'start_time' => '2017-01-02T12:34:56Z' } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/status/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/status/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_status).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/status/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_status }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/status/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_status }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/status/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_status }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/universe_spec.rb
+++ b/spec/lib/esi/client/universe_spec.rb
@@ -1,1696 +1,424 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Universe, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_universe_ancestries" do
-    context "when the response is 200" do
-      let(:response) { [{ "bloodline_id" => 1, "description" => "Acutely aware of the small population...", "id" => 12, "name" => "Tube Child", "short_description" => "Manufactured citizens of the State." }] }
+  describe '#get_universe_ancestries' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'bloodline_id' => 1, 'description' => 'Acutely aware of the small population...', 'id' => 12, 'name' => 'Tube Child', 'short_description' => 'Manufactured citizens of the State.' }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/ancestries/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/ancestries/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_ancestries).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/ancestries/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_ancestries }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_universe_asteroid_belt' do
+    context 'when the response is 200' do
+      let(:response) { { 'name' => 'Tanoo I - Asteroid Belt 1', 'position' => { 'x' => 161_967_513_600, 'y' => 21_288_837_120, 'z' => -73_505_464_320 }, 'system_id' => 30_000_001 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/ancestries/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/asteroid_belts/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_ancestries }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/ancestries/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_ancestries }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_asteroid_belt(asteroid_belt_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_asteroid_belt" do
-    context "when the response is 200" do
-      let(:response) { { "name" => "Tanoo I - Asteroid Belt 1", "position" => { "x" => 161_967_513_600, "y" => 21_288_837_120, "z" => -73_505_464_320 }, "system_id" => 30_000_001 } }
+  describe '#get_universe_bloodlines' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'bloodline_id' => 1, 'charisma' => 6, 'corporation_id' => 1_000_006, 'description' => 'The Deteis are regarded as ...', 'intelligence' => 7, 'memory' => 7, 'name' => 'Deteis', 'perception' => 5, 'race_id' => 1, 'ship_type_id' => 601, 'willpower' => 5 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/asteroid_belts/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/bloodlines/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_asteroid_belt(asteroid_belt_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/asteroid_belts/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_asteroid_belt(asteroid_belt_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/asteroid_belts/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_asteroid_belt(asteroid_belt_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/asteroid_belts/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_asteroid_belt(asteroid_belt_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/asteroid_belts/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_asteroid_belt(asteroid_belt_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_universe_bloodlines" do
-    context "when the response is 200" do
-      let(:response) { [{ "bloodline_id" => 1, "charisma" => 6, "corporation_id" => 1_000_006, "description" => "The Deteis are regarded as ...", "intelligence" => 7, "memory" => 7, "name" => "Deteis", "perception" => 5, "race_id" => 1, "ship_type_id" => 601, "willpower" => 5 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/bloodlines/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_bloodlines).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/bloodlines/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_bloodlines }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/bloodlines/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_bloodlines }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/bloodlines/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_bloodlines }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_universe_categories" do
-    context "when the response is 200" do
+  describe '#get_universe_categories' do
+    context 'when the response is 200' do
       let(:response) { [1, 2, 3] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/categories/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_categories).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_categories }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_universe_categories_category' do
+    context 'when the response is 200' do
+      let(:response) { { 'category_id' => 6, 'groups' => [25, 26, 27], 'name' => 'Ship', 'published' => true } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/categories/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_categories }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_categories }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_categories_category(category_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_categories_category" do
-    context "when the response is 200" do
-      let(:response) { { "category_id" => 6, "groups" => [25, 26, 27], "name" => "Ship", "published" => true } }
+  describe '#get_universe_constellation' do
+    context 'when the response is 200' do
+      let(:response) { { 'constellation_id' => 20_000_009, 'name' => 'Mekashtad', 'position' => { 'x' => 67_796_138_757_472_320, 'y' => -70_591_121_348_560_960, 'z' => -59_587_016_159_270_070 }, 'region_id' => 10_000_001, 'systems' => [20_000_302, 20_000_303] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/constellations/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_categories_category(category_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_categories_category(category_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_categories_category(category_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_categories_category(category_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/categories/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_categories_category(category_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_constellation(constellation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_constellation" do
-    context "when the response is 200" do
-      let(:response) { { "constellation_id" => 20_000_009, "name" => "Mekashtad", "position" => { "x" => 67_796_138_757_472_320, "y" => -70_591_121_348_560_960, "z" => -59_587_016_159_270_070 }, "region_id" => 10_000_001, "systems" => [20_000_302, 20_000_303] } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_universe_constellation(constellation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_constellation(constellation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_constellation(constellation_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_constellation(constellation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_constellation(constellation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_universe_constellations" do
-    context "when the response is 200" do
+  describe '#get_universe_constellations' do
+    context 'when the response is 200' do
       let(:response) { [20_000_001, 20_000_002] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/constellations/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_constellations).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_constellations }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_constellations }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/constellations/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_constellations }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_universe_factions" do
-    context "when the response is 200" do
-      let(:response) { [{ "corporation_id" => 456, "description" => "blah blah", "faction_id" => 1, "is_unique" => true, "name" => "Faction", "size_factor" => 1.0, "solar_system_id" => 123, "station_count" => 1000, "station_system_count" => 100 }] }
+  describe '#get_universe_factions' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'corporation_id' => 456, 'description' => 'blah blah', 'faction_id' => 1, 'is_unique' => true, 'name' => 'Faction', 'size_factor' => 1.0, 'solar_system_id' => 123, 'station_count' => 1000, 'station_system_count' => 100 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/factions/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/factions/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_factions).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/factions/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_factions }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_universe_graphic' do
+    context 'when the response is 200' do
+      let(:response) { { 'graphic_file' => 'res:/dx9/model/worldobject/planet/moon.red', 'graphic_id' => 10 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/factions/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/graphics/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_factions }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/factions/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_factions }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_graphic(graphic_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_graphic" do
-    context "when the response is 200" do
-      let(:response) { { "graphic_file" => "res:/dx9/model/worldobject/planet/moon.red", "graphic_id" => 10 } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_universe_graphic(graphic_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_graphic(graphic_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_graphic(graphic_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_graphic(graphic_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_graphic(graphic_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_universe_graphics" do
-    context "when the response is 200" do
+  describe '#get_universe_graphics' do
+    context 'when the response is 200' do
       let(:response) { [10, 4106] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/graphics/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_graphics).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_graphics }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_universe_group' do
+    context 'when the response is 200' do
+      let(:response) { { 'category_id' => 6, 'group_id' => 25, 'name' => 'Frigate', 'published' => true, 'types' => [587, 586, 585] } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/groups/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_graphics }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/graphics/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_graphics }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_group(group_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_group" do
-    context "when the response is 200" do
-      let(:response) { { "category_id" => 6, "group_id" => 25, "name" => "Frigate", "published" => true, "types" => [587, 586, 585] } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_universe_group(group_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_group(group_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_group(group_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_group(group_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_group(group_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_universe_groups" do
-    context "when the response is 200" do
+  describe '#get_universe_groups' do
+    context 'when the response is 200' do
       let(:response) { [1, 2, 3] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/groups/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_groups).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_groups }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_universe_moon' do
+    context 'when the response is 200' do
+      let(:response) { { 'moon_id' => 40_000_042, 'name' => 'Akpivem I - Moon 1', 'position' => { 'x' => 58_605_102_008, 'y' => -3_066_616_285, 'z' => -55_193_617_920 }, 'system_id' => 30_000_003 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/moons/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_groups }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/groups/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_groups }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_moon(moon_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_moon" do
-    context "when the response is 200" do
-      let(:response) { { "moon_id" => 40_000_042, "name" => "Akpivem I - Moon 1", "position" => { "x" => 58_605_102_008, "y" => -3_066_616_285, "z" => -55_193_617_920 }, "system_id" => 30_000_003 } }
+  describe '#get_universe_planet' do
+    context 'when the response is 200' do
+      let(:response) { { 'name' => 'Akpivem III', 'planet_id' => 40_000_046, 'position' => { 'x' => -189_226_344_497, 'y' => 9_901_605_317, 'z' => -254_852_632_979 }, 'system_id' => 30_000_003, 'type_id' => 13 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/moons/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/planets/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_moon(moon_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/moons/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_moon(moon_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/moons/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_moon(moon_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/moons/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_moon(moon_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/moons/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_moon(moon_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_planet(planet_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_planet" do
-    context "when the response is 200" do
-      let(:response) { { "name" => "Akpivem III", "planet_id" => 40_000_046, "position" => { "x" => -189_226_344_497, "y" => 9_901_605_317, "z" => -254_852_632_979 }, "system_id" => 30_000_003, "type_id" => 13 } }
+  describe '#get_universe_races' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'alliance_id' => 500_001, 'description' => 'Founded on the tenets of patriotism and hard work...', 'name' => 'Caldari', 'race_id' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/planets/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/races/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_planet(planet_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/planets/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_planet(planet_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/planets/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_planet(planet_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/planets/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_planet(planet_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/planets/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_planet(planet_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_universe_races" do
-    context "when the response is 200" do
-      let(:response) { [{ "alliance_id" => 500_001, "description" => "Founded on the tenets of patriotism and hard work...", "name" => "Caldari", "race_id" => 1 }] }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/races/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_races).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/races/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_races }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_universe_region' do
+    context 'when the response is 200' do
+      let(:response) { { 'constellations' => [20_000_302, 20_000_303], 'description' => 'It has long been an established fact of civilization...', 'name' => 'Metropolis', 'region_id' => 10_000_042 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/races/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/regions/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_races }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/races/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_races }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_region(region_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_region" do
-    context "when the response is 200" do
-      let(:response) { { "constellations" => [20_000_302, 20_000_303], "description" => "It has long been an established fact of civilization...", "name" => "Metropolis", "region_id" => 10_000_042 } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_universe_region(region_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_region(region_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_region(region_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_region(region_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_region(region_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_universe_regions" do
-    context "when the response is 200" do
+  describe '#get_universe_regions' do
+    context 'when the response is 200' do
       let(:response) { [11_000_001, 11_000_002] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/regions/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_regions).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_regions }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_universe_star' do
+    context 'when the response is 200' do
+      let(:response) { { 'age' => 9_398_686_722, 'luminosity' => 0.06615000218153, 'name' => 'BKG-Q2 - Star', 'radius' => 346_600_000, 'solar_system_id' => 30_004_333, 'spectral_class' => 'K2 V', 'temperature' => 3953, 'type_id' => 45_033 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/stars/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_regions }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/regions/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_regions }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_star(star_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_star" do
-    context "when the response is 200" do
-      let(:response) { { "age" => 9_398_686_722, "luminosity" => 0.06615000218153, "name" => "BKG-Q2 - Star", "radius" => 346_600_000, "solar_system_id" => 30_004_333, "spectral_class" => "K2 V", "temperature" => 3953, "type_id" => 45_033 } }
+  describe '#get_universe_stargate' do
+    context 'when the response is 200' do
+      let(:response) { { 'destination' => { 'stargate_id' => 50_000_056, 'system_id' => 30_000_001 }, 'name' => 'Stargate (Tanoo)', 'position' => { 'x' => -101_092_761_600, 'y' => 5_279_539_200, 'z' => 1_550_503_403_520 }, 'stargate_id' => 50_000_342, 'system_id' => 30_000_003, 'type_id' => 29_624 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stars/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/stargates/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_star(star_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stars/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_star(star_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stars/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_star(star_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stars/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_star(star_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_stargate(stargate_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_stargate" do
-    context "when the response is 200" do
-      let(:response) { { "destination" => { "stargate_id" => 50_000_056, "system_id" => 30_000_001 }, "name" => "Stargate (Tanoo)", "position" => { "x" => -101_092_761_600, "y" => 5_279_539_200, "z" => 1_550_503_403_520 }, "stargate_id" => 50_000_342, "system_id" => 30_000_003, "type_id" => 29_624 } }
+  describe '#get_universe_station' do
+    context 'when the response is 200' do
+      let(:response) { { 'max_dockable_ship_volume' => 50_000_000, 'name' => 'Jakanerva III - Moon 15 - Prompt Delivery Storage', 'office_rental_cost' => 10_000, 'owner' => 1_000_003, 'position' => { 'x' => 165_632_286_720, 'y' => 2_771_804_160, 'z' => -2_455_331_266_560 }, 'race_id' => 1, 'reprocessing_efficiency' => 0.5, 'reprocessing_stations_take' => 0.05, 'services' => %w[courier-missions reprocessing-plant market repair-facilities fitting news storage insurance docking office-rental loyalty-point-store navy-offices], 'station_id' => 60_000_277, 'system_id' => 30_000_148, 'type_id' => 1531 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stargates/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/stations/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_stargate(stargate_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stargates/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_stargate(stargate_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stargates/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_stargate(stargate_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stargates/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_stargate(stargate_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stargates/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_stargate(stargate_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_station(station_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_station" do
-    context "when the response is 200" do
-      let(:response) { { "max_dockable_ship_volume" => 50_000_000, "name" => "Jakanerva III - Moon 15 - Prompt Delivery Storage", "office_rental_cost" => 10_000, "owner" => 1_000_003, "position" => { "x" => 165_632_286_720, "y" => 2_771_804_160, "z" => -2_455_331_266_560 }, "race_id" => 1, "reprocessing_efficiency" => 0.5, "reprocessing_stations_take" => 0.05, "services" => %w[courier-missions reprocessing-plant market repair-facilities fitting news storage insurance docking office-rental loyalty-point-store navy-offices], "station_id" => 60_000_277, "system_id" => 30_000_148, "type_id" => 1531 } }
+  describe '#get_universe_structure' do
+    context 'when the response is 200' do
+      let(:response) { { 'name' => 'V-3YG7 VI - The Capital', 'owner_id' => 109_299_958, 'solar_system_id' => 30_000_142 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stations/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/structures/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_station(station_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stations/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_station(station_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stations/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_station(station_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stations/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_station(station_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/stations/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_station(station_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_structure(structure_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_structure" do
-    context "when the response is 200" do
-      let(:response) { { "name" => "V-3YG7 VI - The Capital", "owner_id" => 109_299_958, "solar_system_id" => 30_000_142 } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_universe_structure(structure_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/1234567890/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_universe_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/1234567890/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_universe_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_structure(structure_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_universe_structures" do
-    context "when the response is 200" do
+  describe '#get_universe_structures' do
+    context 'when the response is 200' do
       let(:response) { [1_020_988_381_992, 1_020_988_381_991] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/").with(query: { filter: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/structures/').with(query: { filter: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_structures(filter: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/").with(query: { filter: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_structures(filter: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/").with(query: { filter: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_structures(filter: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/structures/").with(query: { filter: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_structures(filter: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_structures(filter: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_system" do
-    context "when the response is 200" do
-      let(:response) { { "constellation_id" => 20_000_001, "name" => "Akpivem", "planets" => [{ "moons" => [40_000_042], "planet_id" => 40_000_041 }, { "planet_id" => 40_000_043 }], "position" => { "x" => -91_174_141_133_075_340, "y" => 43_938_227_486_247_170, "z" => -56_482_824_383_339_900 }, "security_class" => "B", "security_status" => 0.8462923765182495, "star_id" => 40_000_040, "stargates" => [50_000_342], "system_id" => 30_000_003 } }
+  describe '#get_universe_system' do
+    context 'when the response is 200' do
+      let(:response) { { 'constellation_id' => 20_000_001, 'name' => 'Akpivem', 'planets' => [{ 'moons' => [40_000_042], 'planet_id' => 40_000_041 }, { 'planet_id' => 40_000_043 }], 'position' => { 'x' => -91_174_141_133_075_340, 'y' => 43_938_227_486_247_170, 'z' => -56_482_824_383_339_900 }, 'security_class' => 'B', 'security_status' => 0.8462923765182495, 'star_id' => 40_000_040, 'stargates' => [50_000_342], 'system_id' => 30_000_003 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/systems/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_universe_system(system_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_system(system_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_system(system_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_system(system_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_system(system_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_system(system_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_system_jumps" do
-    context "when the response is 200" do
-      let(:response) { [{ "ship_jumps" => 42, "system_id" => 30_002_410 }] }
+  describe '#get_universe_system_jumps' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'ship_jumps' => 42, 'system_id' => 30_002_410 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/system_jumps/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/system_jumps/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_system_jumps).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/system_jumps/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_system_jumps }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/system_jumps/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_system_jumps }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/system_jumps/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_system_jumps }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_universe_system_kills" do
-    context "when the response is 200" do
-      let(:response) { [{ "npc_kills" => 0, "pod_kills" => 24, "ship_kills" => 42, "system_id" => 30_002_410 }] }
+  describe '#get_universe_system_kills' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'npc_kills' => 0, 'pod_kills' => 24, 'ship_kills' => 42, 'system_id' => 30_002_410 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/system_kills/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/system_kills/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_system_kills).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/system_kills/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_system_kills }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/system_kills/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_system_kills }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/system_kills/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_system_kills }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#get_universe_systems" do
-    context "when the response is 200" do
+  describe '#get_universe_systems' do
+    context 'when the response is 200' do
       let(:response) { [30_000_001, 30_000_002] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/systems/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_systems).to eq(response)
       end
     end
+  end
 
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_systems }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
+  describe '#get_universe_type' do
+    context 'when the response is 200' do
+      let(:response) { { 'description' => 'The Rifter is a...', 'group_id' => 25, 'name' => 'Rifter', 'published' => true, 'type_id' => 587 } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/types/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_systems }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/systems/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_systems }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_universe_type(type_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_universe_type" do
-    context "when the response is 200" do
-      let(:response) { { "description" => "The Rifter is a...", "group_id" => 25, "name" => "Rifter", "published" => true, "type_id" => 587 } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_universe_type(type_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_type(type_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/1234567890/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.get_universe_type(type_id: "1234567890") }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_type(type_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_type(type_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
-  end
-
-  describe "#get_universe_types" do
-    context "when the response is 200" do
+  describe '#get_universe_types' do
+    context 'when the response is 200' do
       let(:response) { [1, 2, 3] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/universe/types/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.get_universe_types).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_universe_types }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_universe_types }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/universe/types/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_universe_types }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#post_universe_ids" do
-    context "when the response is 200" do
-      let(:response) { { "characters" => [{ "id" => 95_465_499, "name" => "CCP Bartender" }, { "id" => 2_112_625_428, "name" => "CCP Zoetrope" }], "systems" => [{ "id" => 30_000_142, "name" => "Jita" }] } }
+  describe '#post_universe_ids' do
+    context 'when the response is 200' do
+      let(:response) { { 'characters' => [{ 'id' => 95_465_499, 'name' => 'CCP Bartender' }, { 'id' => 2_112_625_428, 'name' => 'CCP Zoetrope' }], 'systems' => [{ 'id' => 30_000_142, 'name' => 'Jita' }] } }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/ids/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/universe/ids/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.post_universe_ids(names: [1, 2, 3])).to eq(response)
       end
     end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/ids/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_universe_ids(names: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/ids/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_universe_ids(names: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/ids/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_universe_ids(names: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
-      end
-    end
   end
 
-  describe "#post_universe_names" do
-    context "when the response is 200" do
-      let(:response) { [{ "category" => "character", "id" => 95_465_499, "name" => "CCP Bartender" }, { "category" => "solar_system", "id" => 30_000_142, "name" => "Jita" }] }
+  describe '#post_universe_names' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'category' => 'character', 'id' => 95_465_499, 'name' => 'CCP Bartender' }, { 'category' => 'solar_system', 'id' => 30_000_142, 'name' => 'Jita' }] }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/names/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/universe/names/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
+      it 'returns the response' do
         expect(client.post_universe_names(ids: [1, 2, 3])).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/names/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_universe_names(ids: [1, 2, 3]) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 404" do
-      let(:response) { { "error" => "Not found message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/names/").to_return(body: response.to_json, status: 404, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::NotFoundError error" do
-        expect { client.post_universe_names(ids: [1, 2, 3]) }.to raise_error(ESI::Errors::NotFoundError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/names/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_universe_names(ids: [1, 2, 3]) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/universe/names/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_universe_names(ids: [1, 2, 3]) }.to raise_error(ESI::Errors::InternalServerError)
       end
     end
   end

--- a/spec/lib/esi/client/user_interface_spec.rb
+++ b/spec/lib/esi/client/user_interface_spec.rb
@@ -1,386 +1,74 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::UserInterface, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#post_ui_autopilot_waypoint" do
-    context "when the response is 204" do
+  describe '#post_ui_autopilot_waypoint' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/autopilot/waypoint/").with(query: { add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/ui/autopilot/waypoint/').with(query: { add_to_beginning: '1234567890', clear_other_waypoints: '1234567890', destination_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_ui_autopilot_waypoint(add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/autopilot/waypoint/").with(query: { add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_ui_autopilot_waypoint(add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/autopilot/waypoint/").with(query: { add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_ui_autopilot_waypoint(add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/autopilot/waypoint/").with(query: { add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_ui_autopilot_waypoint(add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/autopilot/waypoint/").with(query: { add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_ui_autopilot_waypoint(add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/autopilot/waypoint/").with(query: { add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_ui_autopilot_waypoint(add_to_beginning: "1234567890", clear_other_waypoints: "1234567890", destination_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_ui_autopilot_waypoint(add_to_beginning: '1234567890', clear_other_waypoints: '1234567890', destination_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_ui_openwindow_contract" do
-    context "when the response is 204" do
+  describe '#post_ui_openwindow_contract' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/contract/").with(query: { contract_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/ui/openwindow/contract/').with(query: { contract_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_ui_openwindow_contract(contract_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/contract/").with(query: { contract_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_ui_openwindow_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/contract/").with(query: { contract_id: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_ui_openwindow_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/contract/").with(query: { contract_id: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_ui_openwindow_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/contract/").with(query: { contract_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_ui_openwindow_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/contract/").with(query: { contract_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_ui_openwindow_contract(contract_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_ui_openwindow_contract(contract_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_ui_openwindow_information" do
-    context "when the response is 204" do
+  describe '#post_ui_openwindow_information' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/information/").with(query: { target_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/ui/openwindow/information/').with(query: { target_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_ui_openwindow_information(target_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/information/").with(query: { target_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_ui_openwindow_information(target_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/information/").with(query: { target_id: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_ui_openwindow_information(target_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/information/").with(query: { target_id: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_ui_openwindow_information(target_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/information/").with(query: { target_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_ui_openwindow_information(target_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/information/").with(query: { target_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_ui_openwindow_information(target_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_ui_openwindow_information(target_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_ui_openwindow_marketdetails" do
-    context "when the response is 204" do
+  describe '#post_ui_openwindow_marketdetails' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/marketdetails/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/ui/openwindow/marketdetails/').with(query: { type_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_ui_openwindow_marketdetails(type_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/marketdetails/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_ui_openwindow_marketdetails(type_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/marketdetails/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_ui_openwindow_marketdetails(type_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/marketdetails/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_ui_openwindow_marketdetails(type_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/marketdetails/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_ui_openwindow_marketdetails(type_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/marketdetails/").with(query: { type_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_ui_openwindow_marketdetails(type_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_ui_openwindow_marketdetails(type_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#post_ui_openwindow_newmail" do
-    context "when the response is 204" do
+  describe '#post_ui_openwindow_newmail' do
+    context 'when the response is 204' do
       let(:response) { nil }
 
       before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/newmail/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:post, 'https://esi.evetech.net/latest/ui/openwindow/newmail/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.post_ui_openwindow_newmail(new_mail: { "foo" => "bar" })).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/newmail/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.post_ui_openwindow_newmail(new_mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/newmail/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.post_ui_openwindow_newmail(new_mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/newmail/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.post_ui_openwindow_newmail(new_mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/newmail/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.post_ui_openwindow_newmail(new_mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "Unprocessable entity message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/newmail/").to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.post_ui_openwindow_newmail(new_mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:post, "https://esi.evetech.net/latest/ui/openwindow/newmail/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.post_ui_openwindow_newmail(new_mail: { "foo" => "bar" }) }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.post_ui_openwindow_newmail(new_mail: { 'foo' => 'bar' })).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/wallet_spec.rb
+++ b/spec/lib/esi/client/wallet_spec.rb
@@ -1,448 +1,88 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::Wallet, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_character_wallet" do
-    context "when the response is 200" do
+  describe '#get_character_wallet' do
+    context 'when the response is 200' do
       let(:response) { 29_500.01 }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/wallet/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_wallet(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_wallet(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_wallet(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_wallet(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_wallet(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_wallet(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_wallet(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_wallet_journal" do
-    context "when the response is 200" do
-      let(:response) { [{ "amount" => -100_000, "balance" => 500_000.4316, "context_id" => 4, "context_id_type" => "contract_id", "date" => "2018-02-23T14:31:32Z", "description" => "Contract Deposit", "first_party_id" => 2_112_625_428, "id" => 89, "ref_type" => "contract_deposit", "second_party_id" => 1_000_132 }] }
+  describe '#get_character_wallet_journal' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'amount' => -100_000, 'balance' => 500_000.4316, 'context_id' => 4, 'context_id_type' => 'contract_id', 'date' => '2018-02-23T14:31:32Z', 'description' => 'Contract Deposit', 'first_party_id' => 2_112_625_428, 'id' => 89, 'ref_type' => 'contract_deposit', 'second_party_id' => 1_000_132 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/journal/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/wallet/journal/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_wallet_journal(character_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/journal/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_wallet_journal(character_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/journal/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_wallet_journal(character_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/journal/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_wallet_journal(character_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/journal/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_wallet_journal(character_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/journal/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_wallet_journal(character_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_wallet_journal(character_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_character_wallet_transactions" do
-    context "when the response is 200" do
-      let(:response) { [{ "client_id" => 54_321, "date" => "2016-10-24T09:00:00Z", "is_buy" => true, "is_personal" => true, "journal_ref_id" => 67_890, "location_id" => 60_014_719, "quantity" => 1, "transaction_id" => 1_234_567_890, "type_id" => 587, "unit_price" => 1 }] }
+  describe '#get_character_wallet_transactions' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'client_id' => 54_321, 'date' => '2016-10-24T09:00:00Z', 'is_buy' => true, 'is_personal' => true, 'journal_ref_id' => 67_890, 'location_id' => 60_014_719, 'quantity' => 1, 'transaction_id' => 1_234_567_890, 'type_id' => 587, 'unit_price' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/wallet/transactions/').with(query: { from_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_character_wallet_transactions(character_id: "1234567890", from_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_character_wallet_transactions(character_id: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_character_wallet_transactions(character_id: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_character_wallet_transactions(character_id: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_character_wallet_transactions(character_id: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/characters/1234567890/wallet/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_character_wallet_transactions(character_id: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_character_wallet_transactions(character_id: '1234567890', from_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_wallets" do
-    context "when the response is 200" do
-      let(:response) { [{ "balance" => 123.45, "division" => 1 }, { "balance" => 123.45, "division" => 2 }, { "balance" => 123.45, "division" => 3 }, { "balance" => 123.45, "division" => 4 }, { "balance" => 123.45, "division" => 5 }, { "balance" => 123.45, "division" => 6 }, { "balance" => 123.45, "division" => 7 }] }
+  describe '#get_corporation_wallets' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'balance' => 123.45, 'division' => 1 }, { 'balance' => 123.45, 'division' => 2 }, { 'balance' => 123.45, 'division' => 3 }, { 'balance' => 123.45, 'division' => 4 }, { 'balance' => 123.45, 'division' => 5 }, { 'balance' => 123.45, 'division' => 6 }, { 'balance' => 123.45, 'division' => 7 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/wallets/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_wallets(corporation_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_wallets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_wallets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_wallets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_wallets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_wallets(corporation_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_wallets(corporation_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_wallets_division_journal" do
-    context "when the response is 200" do
-      let(:response) { [{ "amount" => -1000, "balance" => 100_000.0, "context_id" => 2_112_625_428, "context_id_type" => "character_id", "date" => "2016-10-24T09:00:00Z", "description" => "CCP Zoetrope transferred cash from C C P's corporate account to CCP SnowedIn's account", "first_party_id" => 109_299_958, "id" => 1_234_567_890, "ref_type" => "corporation_account_withdrawal", "second_party_id" => 95_538_921 }] }
+  describe '#get_corporation_wallets_division_journal' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'amount' => -1000, 'balance' => 100_000.0, 'context_id' => 2_112_625_428, 'context_id_type' => 'character_id', 'date' => '2016-10-24T09:00:00Z', 'description' => "CCP Zoetrope transferred cash from C C P's corporate account to CCP SnowedIn's account", 'first_party_id' => 109_299_958, 'id' => 1_234_567_890, 'ref_type' => 'corporation_account_withdrawal', 'second_party_id' => 95_538_921 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/journal/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/journal/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_wallets_division_journal(corporation_id: "1234567890", division: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/journal/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_wallets_division_journal(corporation_id: "1234567890", division: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/journal/").to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_wallets_division_journal(corporation_id: "1234567890", division: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/journal/").to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_wallets_division_journal(corporation_id: "1234567890", division: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/journal/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_wallets_division_journal(corporation_id: "1234567890", division: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/journal/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_wallets_division_journal(corporation_id: "1234567890", division: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_wallets_division_journal(corporation_id: '1234567890', division: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_corporation_wallets_division_transactions" do
-    context "when the response is 200" do
-      let(:response) { [{ "client_id" => 54_321, "date" => "2016-10-24T09:00:00Z", "is_buy" => true, "journal_ref_id" => 67_890, "location_id" => 60_014_719, "quantity" => 1, "transaction_id" => 1_234_567_890, "type_id" => 587, "unit_price" => 1 }] }
+  describe '#get_corporation_wallets_division_transactions' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'client_id' => 54_321, 'date' => '2016-10-24T09:00:00Z', 'is_buy' => true, 'journal_ref_id' => 67_890, 'location_id' => 60_014_719, 'quantity' => 1, 'transaction_id' => 1_234_567_890, 'type_id' => 587, 'unit_price' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/transactions/').with(query: { from_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_corporation_wallets_division_transactions(corporation_id: "1234567890", division: "1234567890", from_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_corporation_wallets_division_transactions(corporation_id: "1234567890", division: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 401" do
-      let(:response) { { "error" => "Unauthorized message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 401, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnauthorizedError error" do
-        expect { client.get_corporation_wallets_division_transactions(corporation_id: "1234567890", division: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::UnauthorizedError)
-      end
-    end
-
-    context "when the response is 403" do
-      let(:response) { { "error" => "Forbidden message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 403, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ForbiddenError error" do
-        expect { client.get_corporation_wallets_division_transactions(corporation_id: "1234567890", division: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::ForbiddenError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_corporation_wallets_division_transactions(corporation_id: "1234567890", division: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/corporations/1234567890/wallets/1234567890/transactions/").with(query: { from_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_corporation_wallets_division_transactions(corporation_id: "1234567890", division: "1234567890", from_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_corporation_wallets_division_transactions(corporation_id: '1234567890', division: '1234567890', from_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client/wars_spec.rb
+++ b/spec/lib/esi/client/wars_spec.rb
@@ -1,178 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client::War, type: :stub do
-  subject(:client) { ESI::Client.new(user_agent: "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)") }
+  subject(:client) { ESI::Client.new(retries: 2, user_agent: 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)') }
 
-  describe "#get_war" do
-    context "when the response is 200" do
-      let(:response) { { "aggressor" => { "corporation_id" => 986_665_792, "isk_destroyed" => 0, "ships_killed" => 0 }, "declared" => "2004-05-22T05:20:00Z", "defender" => { "corporation_id" => 1_001_562_011, "isk_destroyed" => 0, "ships_killed" => 0 }, "id" => 1941, "mutual" => false, "open_for_allies" => false } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/").to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
-      end
-
-      it "returns the response" do
-        expect(client.get_war(war_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
+  describe '#get_war' do
+    context 'when the response is 200' do
+      let(:response) { { 'aggressor' => { 'corporation_id' => 986_665_792, 'isk_destroyed' => 0, 'ships_killed' => 0 }, 'declared' => '2004-05-22T05:20:00Z', 'defender' => { 'corporation_id' => 1_001_562_011, 'isk_destroyed' => 0, 'ships_killed' => 0 }, 'id' => 1941, 'mutual' => false, 'open_for_allies' => false } }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/wars/1234567890/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_war(war_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_war(war_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "Unprocessable entity message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/").to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.get_war(war_id: "1234567890") }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_war(war_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_war(war_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_war_killmails" do
-    context "when the response is 200" do
-      let(:response) { [{ "killmail_hash" => "8eef5e8fb6b88fe3407c489df33822b2e3b57a5e", "killmail_id" => 2 }, { "killmail_hash" => "b41ccb498ece33d64019f64c0db392aa3aa701fb", "killmail_id" => 1 }] }
+  describe '#get_war_killmails' do
+    context 'when the response is 200' do
+      let(:response) { [{ 'killmail_hash' => '8eef5e8fb6b88fe3407c489df33822b2e3b57a5e', 'killmail_id' => 2 }, { 'killmail_hash' => 'b41ccb498ece33d64019f64c0db392aa3aa701fb', 'killmail_id' => 1 }] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/killmails/").to_return(body: response.to_json, headers: { "Content-Type": "application/json", "X-Pages": "1" })
+        stub_request(:get, 'https://esi.evetech.net/latest/wars/1234567890/killmails/').to_return(body: response.to_json, headers: { 'Content-Type': 'application/json', 'X-Pages': '1' })
       end
 
-      it "returns the response" do
-        expect(client.get_war_killmails(war_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/killmails/").to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_war_killmails(war_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/killmails/").to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_war_killmails(war_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 422" do
-      let(:response) { { "error" => "Unprocessable entity message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/killmails/").to_return(body: response.to_json, status: 422, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::UnprocessableEntityError error" do
-        expect { client.get_war_killmails(war_id: "1234567890") }.to raise_error(ESI::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/1234567890/killmails/").to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_war_killmails(war_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_war_killmails(war_id: '1234567890')).to eq(response)
       end
     end
   end
 
-  describe "#get_wars" do
-    context "when the response is 200" do
+  describe '#get_wars' do
+    context 'when the response is 200' do
       let(:response) { [3, 2, 1] }
 
       before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/").with(query: { max_war_id: "1234567890" }).to_return(body: response.to_json, headers: { "Content-Type": "application/json" })
+        stub_request(:get, 'https://esi.evetech.net/latest/wars/').with(query: { max_war_id: '1234567890' }).to_return(body: response.to_json, headers: { 'Content-Type': 'application/json' })
       end
 
-      it "returns the response" do
-        expect(client.get_wars(max_war_id: "1234567890")).to eq(response)
-      end
-    end
-
-    context "when the response is 400" do
-      let(:response) { { "error" => "Bad request message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/").with(query: { max_war_id: "1234567890" }).to_return(body: response.to_json, status: 400, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::BadRequestError error" do
-        expect { client.get_wars(max_war_id: "1234567890") }.to raise_error(ESI::Errors::BadRequestError)
-      end
-    end
-
-    context "when the response is 420" do
-      let(:response) { { "error" => "Error limited message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/").with(query: { max_war_id: "1234567890" }).to_return(body: response.to_json, status: 420, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::ErrorLimitedError error" do
-        expect { client.get_wars(max_war_id: "1234567890") }.to raise_error(ESI::Errors::ErrorLimitedError)
-      end
-    end
-
-    context "when the response is 500" do
-      let(:response) { { "error" => "Internal server error message" } }
-
-      before do
-        stub_request(:get, "https://esi.evetech.net/latest/wars/").with(query: { max_war_id: "1234567890" }).to_return(body: response.to_json, status: 500, headers: { "Content-Type": "application/json" })
-      end
-
-      it "raises a ESI::Errors::InternalServerError error" do
-        expect { client.get_wars(max_war_id: "1234567890") }.to raise_error(ESI::Errors::InternalServerError)
+      it 'returns the response' do
+        expect(client.get_wars(max_war_id: '1234567890')).to eq(response)
       end
     end
   end

--- a/spec/lib/esi/client_spec.rb
+++ b/spec/lib/esi/client_spec.rb
@@ -1,11 +1,200 @@
 # frozen_string_literal: true
 
 RSpec.describe ESI::Client do
-  subject(:client) { ESI::Client.new(user_agent: user_agent) }
+  subject(:client) { ESI::Client.new(user_agent: user_agent, retries: 2) }
 
-  let(:user_agent) { "esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)" }
+  let(:user_agent) { 'esi-sdk-ruby Tests/1.0; +(https://github.com/bokoboshahni/esi-sdk-ruby)' }
 
-  it "can be instantiated" do
+  it 'can be instantiated' do
     expect(client).to be_a(ESI::Client)
+  end
+
+  describe 'error handling without pagination' do
+    context 'when the response is 400' do
+      let(:response) { { 'error' => 'Bad request message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/agents_research/').to_return(
+          body: response.to_json, status: 400, headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'raises a ESI::Errors::BadRequestError error' do
+        expect do
+          client.get_character_agents_research(character_id: '1234567890')
+        end.to raise_error(ESI::Errors::BadRequestError)
+      end
+    end
+
+    context 'when the response is 401' do
+      let(:response) { { 'error' => 'Unauthorized message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/agents_research/').to_return(
+          body: response.to_json, status: 401, headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'raises a ESI::Errors::UnauthorizedError error' do
+        expect do
+          client.get_character_agents_research(character_id: '1234567890')
+        end.to raise_error(ESI::Errors::UnauthorizedError)
+      end
+    end
+
+    context 'when the response is 403' do
+      let(:response) { { 'error' => 'Forbidden message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/agents_research/').to_return(
+          body: response.to_json, status: 403, headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'raises a ESI::Errors::ForbiddenError error' do
+        expect do
+          client.get_character_agents_research(character_id: '1234567890')
+        end.to raise_error(ESI::Errors::ForbiddenError)
+      end
+    end
+
+    context 'when the response is 420' do
+      let(:response) { { 'error' => 'Error limited message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/agents_research/').to_return(
+          body: response.to_json, status: 420, headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'raises a ESI::Errors::ErrorLimitedError error' do
+        expect do
+          client.get_character_agents_research(character_id: '1234567890')
+        end.to raise_error(ESI::Errors::ErrorLimitedError)
+      end
+    end
+
+    context 'when the response is 500' do
+      let(:response) { { 'error' => 'Internal server error message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/characters/1234567890/agents_research/').to_return(
+          body: response.to_json, status: 500, headers: { 'Content-Type': 'application/json' }
+        )
+      end
+
+      it 'raises a ESI::Errors::InternalServerError error' do
+        expect do
+          client.get_character_agents_research(character_id: '1234567890')
+        end.to raise_error(ESI::Errors::InternalServerError)
+      end
+    end
+  end
+
+  describe 'error handling with pagination' do
+    let(:response) do
+      [{ 'duration' => 90, 'is_buy_order' => false, 'issued' => '2016-09-03T05:12:25Z', 'location_id' => 60_005_599,
+         'min_volume' => 1, 'order_id' => 4_623_824_223, 'price' => 9.9, 'range' => 'region', 'system_id' => 30_000_053, 'type_id' => 34, 'volume_remain' => 1_296_000, 'volume_total' => 2_000_000 }]
+    end
+
+    context 'when the response is 400' do
+      let(:error_response) { { 'error' => 'Bad request message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: response.to_json, status: 200, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/?page=2').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: error_response.to_json, status: 400, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+      end
+
+      it 'raises a ESI::Errors::BadRequestError error' do
+        expect do
+          client.get_markets_region_orders(region_id: '1234567890', order_type: '1234567890',
+                                           type_id: '1234567890')
+        end.to raise_error(ESI::Errors::BadRequestError)
+      end
+    end
+
+    context 'when the response is 404' do
+      let(:error_response) { { 'error' => 'Not found message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: response.to_json, status: 200, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/?page=2').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: error_response.to_json, status: 404, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+      end
+
+      it 'raises a ESI::Errors::NotFoundError error' do
+        expect do
+          client.get_markets_region_orders(region_id: '1234567890', order_type: '1234567890',
+                                           type_id: '1234567890')
+        end.to raise_error(ESI::Errors::NotFoundError)
+      end
+    end
+
+    context 'when the response is 420' do
+      let(:error_response) { { 'error' => 'Error limited message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: response.to_json, status: 200, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/?page=2').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: error_response.to_json, status: 420, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+      end
+
+      it 'raises a ESI::Errors::ErrorLimitedError error' do
+        expect do
+          client.get_markets_region_orders(region_id: '1234567890', order_type: '1234567890',
+                                           type_id: '1234567890')
+        end.to raise_error(ESI::Errors::ErrorLimitedError)
+      end
+    end
+
+    context 'when the response is 422' do
+      let(:error_response) { { 'error' => 'Unprocessable entity message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: response.to_json, status: 200, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/?page=2').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: error_response.to_json, status: 422, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+      end
+
+      it 'raises a ESI::Errors::UnprocessableEntityError error' do
+        expect do
+          client.get_markets_region_orders(region_id: '1234567890', order_type: '1234567890',
+                                           type_id: '1234567890')
+        end.to raise_error(ESI::Errors::UnprocessableEntityError)
+      end
+    end
+
+    context 'when the response is 500' do
+      let(:error_response) { { 'error' => 'Internal server error message' } }
+
+      before do
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: response.to_json, status: 200, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+        stub_request(:get, 'https://esi.evetech.net/latest/markets/1234567890/orders/?page=2').with(query: { order_type: '1234567890', type_id: '1234567890' }).to_return(
+          body: error_response.to_json, status: 500, headers: { 'Content-Type': 'application/json', 'X-Pages': 2 }
+        )
+      end
+
+      it 'raises a ESI::Errors::InternalServerError error' do
+        expect do
+          client.get_markets_region_orders(region_id: '1234567890', order_type: '1234567890',
+                                           type_id: '1234567890')
+        end.to raise_error(ESI::Errors::InternalServerError)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "esi-sdk"
+require 'esi-sdk'
 
-require "simplecov"
+require 'simplecov'
 # require "simplecov_json_formatter"
 
 # SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
@@ -11,41 +11,15 @@ require "simplecov"
 #                                                                ])
 SimpleCov.start
 
-require "webmock/rspec"
-require "httpx/adapters/webmock"
+require 'awesome_print'
 
-module WebMock
-  module HttpLibAdapters
-    module Plugin
-      module InstanceMethods
-        private
-
-        def _build_webmock_request_signature(request) # rubocop:disable Metrics/AbcSize
-          request.uri.query = request.query if request.query
-          uri = WebMock::Util::URI.heuristic_parse(request.uri)
-          uri.path = uri.normalized_path.gsub("[^:]//", "/")
-
-          WebMock::RequestSignature.new(
-            request.verb,
-            uri.to_s,
-            body: request.body.each.to_a.join,
-            headers: request.headers.to_h
-          )
-        end
-      end
-    end
-  end
-end
-
-WebMock.disable_net_connect!
-
-require "awesome_print"
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
 
-  config.default_formatter = config.files_to_run.one? ? "doc" : "progress"
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.default_formatter = config.files_to_run.one? ? 'doc' : 'progress'
+  config.example_status_persistence_file_path = '.rspec_status'
   config.order = :random
   config.shared_context_metadata_behavior = :apply_to_host_groups
 


### PR DESCRIPTION
Includes a new `:retries` option for `ESI::Client#initialize` that
determines the number of tries before raising an error.

BREAKING CHANGE: Typhoeus is now used instead of HTTPX for API calls and
oj is used for JSON parsing.

The following options have been removed from `ESI::Client#initialize`:

- `:cache`: Configure Typhoeus cache globally with
  `Typhoeus::Config.cache`
  (see https://github.com/typhoeus/typhoeus#caching)
- `:logger`: Configure Ethon logger globally with `Ethon.logger`
  (see https://www.rubydoc.info/github/typhoeus/ethon/Ethon/Loggable#logger=-instance_method)
- `:instrumentation`: Instrumentation support to be re-added in a later
  release.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change with a maintainer, please mention her/him using the `@` syntax (e.g. `@bokoboshahni`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [bokobo.space Discord](https://discord.gg/cyjjZ45c).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I have read the [security policy](../security/policy)
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [shahni@bokobo.space](mailto:shahni@bokobo.space)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
